### PR TITLE
Fix: Don't steal focus when attaching to tabs

### DIFF
--- a/extensions/shared/handlers/tabs.js
+++ b/extensions/shared/handlers/tabs.js
@@ -205,7 +205,7 @@ export class TabHandlers {
    */
   async selectTab(params) {
     const tabIndex = params.tabIndex;
-    const activate = params.activate !== false;
+    const activate = params.activate ?? false; // Default to false - don't steal focus
     const stealth = params.stealth ?? false;
 
     // Get all tabs

--- a/server/src/unifiedBackend.js
+++ b/server/src/unifiedBackend.js
@@ -825,7 +825,7 @@ class UnifiedBackend {
     if (action === 'attach') {
       const result = await this._transport.sendCommand('selectTab', {
         tabIndex: args.index,
-        activate: args.activate !== false,
+        activate: args.activate ?? false, // Default to false - don't steal focus
         stealth: args.stealth || false
       });
 


### PR DESCRIPTION
## Summary

Fixes browser_tabs attach action to not activate/focus the browser window by default. Previously, attaching to any tab would bring the browser window to the foreground, which was disruptive when working with the browser in the background.

## Problem

When using browser_tabs action='attach' index=N, the browser window would always come to the foreground and steal focus from the user's current application. This was annoying when monitoring or debugging tabs in the background.

## Solution

Changed the activate parameter default from true to false for the attach action. This matches the documented behavior in the tool schema.

## Changes

Extension (extensions/shared/handlers/tabs.js):
- Before: const activate = params.activate !== false
- After: const activate = params.activate ?? false

Server (server/src/unifiedBackend.js):
- Before: activate: args.activate !== false
- After: activate: args.activate ?? false

## Behavior

- Before: Attaching to tab always brought browser to foreground
- After: Attaching to tab keeps browser in background (silent attachment)
- Opt-in: Users can still pass activate=true to get old behavior if needed

## Testing

✅ Tested attaching to multiple tabs - browser stays in background
✅ No focus stealing confirmed
✅ Extension and server both updated consistently