### PR TITLE
Fix browser_list showing incorrect 'FREE mode' error in PRO mode

### DIFF
--- a/server/src/statefulBackend.js
+++ b/server/src/statefulBackend.js
@@ -860,7 +860,7 @@ class StatefulBackend {
     }
 
     // Must be in PRO mode (proxy mode)
-    if (!this._mcpConnection) {
+    if (!this._proxyConnection) {
       return {
         content: [{
           type: 'text',
@@ -878,7 +878,7 @@ class StatefulBackend {
     try {
       // Get list of available browsers from relay
       debugLog('[StatefulBackend] Requesting list of extensions from relay...');
-      const result = await this._mcpConnection.sendRequest('list_extensions', {});
+      const result = await this._proxyConnection.sendRequest('list_extensions', {});
 
       const browsers = result.extensions || [];
       debugLog(`[StatefulBackend] Found ${browsers.length} browser(s)`);


### PR DESCRIPTION
## Summary

Fixes browser_list incorrectly showing "You are currently in FREE mode" error when user is authenticated in PRO mode.

## Problem

When users were connected in PRO mode and tried to list browsers (e.g., to switch between multiple connected browsers), they received a confusing error message:

```
Error: ### ⚠️ PRO Mode Only

`browser_list` only works in PRO mode (proxy connection).

You are currently in FREE mode (direct local connection).
```

This was incorrect - the status header showed "✅ PRO v1.9.2" indicating they were in PRO mode.

## Root Cause

Variable name typo in `_handleBrowserList()` function:
- The actual variable name is `this._proxyConnection`
- But the code was checking `this._mcpConnection` (which doesn't exist)
- Since `_mcpConnection` was undefined, it always triggered the FREE mode error

Additional inconsistency:
- Status header checks `this._isAuthenticated` to show "PRO" or "FREE"
- But browser_list checked `this._mcpConnection`
- These could be out of sync

## Changes

**File: `server/src/statefulBackend.js`**

- Line 863: Changed `if (!this._mcpConnection)` to `if (!this._proxyConnection)`
- Line 881: Changed `this._mcpConnection.sendRequest` to `this._proxyConnection.sendRequest`

## Testing

- ✅ All unit tests passing (76 passed, 15 skipped)
- ✅ No test failures introduced

## Impact

Users in PRO mode with multiple browsers can now successfully:
- Call `browser_list` to see available browsers
- Switch between browsers using `browser_connect`
- No more confusing "FREE mode" errors when already in PRO mode
