### PR TITLE
Refactor naming to be browser-agnostic

### DIFF
--- a/server/cli.js
+++ b/server/cli.js
@@ -39,7 +39,7 @@ function resolveConfig(options) {
     debug: options.debug === true,
     port: options.port || 5555,
     server: {
-      name: 'Blueprint MCP for Chrome',
+      name: 'Blueprint MCP for Browser',
       version: packageJSON.version
     }
   };
@@ -225,8 +225,8 @@ const program = new Command();
 
 program
   .version('Version ' + packageJSON.version)
-  .name('Blueprint MCP for Chrome')
-  .description('MCP server for Chrome browser automation using the Blueprint MCP extension')
+  .name('Blueprint MCP for Browser')
+  .description('MCP server for browser automation (Chrome, Firefox, Edge, Opera) using the Blueprint MCP extension')
   .option('--debug', 'Enable debug mode (shows reload/extension tools and verbose logging)')
   .option('--log-file <path>', 'Custom log file path (default: logs/mcp-debug.log)')
   .option('--port <number>', 'WebSocket server port (default: 5555)', parseInt)

--- a/server/src/statefulBackend.js
+++ b/server/src/statefulBackend.js
@@ -187,7 +187,7 @@ class StatefulBackend {
     const connectionTools = [
       {
         name: 'enable',
-        description: 'STEP 1: Enable browser automation. Activates the Chrome extension connection and makes browser_ tools available. Provide a client_id (e.g., your project name) for stable connection tracking. In PRO mode with multiple browsers, this will return a list to choose from.',
+        description: 'STEP 1: Enable browser automation. Activates the browser extension connection and makes browser_ tools available. Provide a client_id (e.g., your project name) for stable connection tracking. In PRO mode with multiple browsers, this will return a list to choose from.',
         inputSchema: {
           type: 'object',
           properties: {
@@ -211,7 +211,7 @@ class StatefulBackend {
       },
       {
         name: 'disable',
-        description: 'Disable browser automation and return to passive mode. Closes Chrome extension connection. After this, browser_ tools will not work until you call enable again.',
+        description: 'Disable browser automation and return to passive mode. Closes browser extension connection. After this, browser_ tools will not work until you call enable again.',
         inputSchema: { type: 'object', properties: {}, required: [] },
         annotations: {
           title: 'Disable browser automation',
@@ -487,7 +487,7 @@ class StatefulBackend {
       await this._activeBackend.initialize(this._server, this._clientInfo, this);
 
       this._state = 'active';
-      this._connectedBrowserName = 'Local Chrome';  // Store browser name for standalone mode
+      this._connectedBrowserName = 'Local Browser';  // Store browser name for standalone mode
 
       debugLog('[StatefulBackend] Standalone mode activated');
 
@@ -601,10 +601,10 @@ class StatefulBackend {
                         `**MCP Server:** v${version}\n` +
                         `**Tried:** ${maxRetries} times over 14 seconds\n\n` +
                         `The extension might still be connecting. Please:\n` +
-                        `1. Check that the Chrome extension is installed and enabled\n` +
+                        `1. Check that the browser extension is installed and enabled\n` +
                         `2. Click the extension icon to verify it shows "Connected"\n` +
                         `3. Wait a few seconds and try again\n\n` +
-                        `If the problem persists, try reloading the extension or restarting Chrome.`);
+                        `If the problem persists, try reloading the extension or restarting your browser.`);
       }
 
       if (browsers.length === 1) {
@@ -662,7 +662,7 @@ class StatefulBackend {
 
         this._proxyConnection = mcpConnection;
         this._state = 'connected';
-        this._connectedBrowserName = browsers[0].name || 'Chrome';  // Store browser name
+        this._connectedBrowserName = browsers[0].name || 'Browser';  // Store browser name
 
         debugLog('[StatefulBackend] Successfully auto-connected to single browser');
 
@@ -708,10 +708,10 @@ class StatefulBackend {
 
         // Format the browser list
         let browserList = '### 🔍 Multiple Browsers Found\n\n';
-        browserList += `Found ${browsers.length} Chrome browsers connected to the proxy:\n\n`;
+        browserList += `Found ${browsers.length} browsers connected to the proxy:\n\n`;
 
         browsers.forEach((browser, index) => {
-          browserList += `${index + 1}. **${browser.name || 'Chrome Browser'}**\n`;
+          browserList += `${index + 1}. **${browser.name || 'Browser'}**\n`;
           browserList += `   - ID: \`${browser.id}\`\n`;
           if (browser.version) {
             browserList += `   - Version: ${browser.version}\n`;
@@ -893,7 +893,7 @@ class StatefulBackend {
             text: `### No Browsers Available\n\n` +
                   `No browser extensions are currently connected to the relay.\n\n` +
                   `**To connect a browser:**\n` +
-                  `1. Open Chrome/Firefox with Blueprint MCP extension installed\n` +
+                  `1. Open your browser (Chrome/Firefox/Edge/Opera) with Blueprint MCP extension installed\n` +
                   `2. Extension should auto-connect to the relay\n` +
                   `3. Call \`browser_list\` again to see it`
           }],
@@ -1129,7 +1129,7 @@ class StatefulBackend {
 
       this._proxyConnection = mcpConnection;
       this._state = 'connected';
-      this._connectedBrowserName = selectedBrowser.name || 'Chrome';  // Store browser name
+      this._connectedBrowserName = selectedBrowser.name || 'Browser';  // Store browser name
       this._lastConnectedBrowserId = selectedBrowser.id; // Remember for auto-reconnect
       this._browserDisconnected = false; // Reset disconnected flag
       this._availableBrowsers = null; // Clear the cache

--- a/server/src/unifiedBackend.js
+++ b/server/src/unifiedBackend.js
@@ -506,12 +506,12 @@ class UnifiedBackend {
       // Extension management
       {
         name: 'browser_list_extensions',
-        description: 'List installed Chrome extensions',
+        description: 'List installed browser extensions',
         inputSchema: { type: 'object', properties: {} }
       },
       {
         name: 'browser_reload_extensions',
-        description: 'Reload unpacked/development Chrome extensions. Only works for extensions loaded from a folder (chrome://extensions -> "Load unpacked"). Does not work for packed extensions from Chrome Web Store.',
+        description: 'Reload unpacked/development browser extensions. Only works for extensions loaded from a folder. Does not work for packed extensions installed from browser web stores.',
         inputSchema: {
           type: 'object',
           properties: {
@@ -586,7 +586,7 @@ class UnifiedBackend {
             } else if (browsers.length === 1) {
               errorText += `**Found 1 browser:** ${browsers[0].name}\n\n`;
               errorText += `Reconnection to this browser failed. **Please try:**\n`;
-              errorText += `1. Reload the extension: chrome://extensions/ → Reload\n`;
+              errorText += `1. Reload the extension in your browser\n`;
               errorText += `2. Wait a few seconds\n`;
               errorText += `3. Try this command again (auto-reconnect will retry)`;
             } else {
@@ -4484,7 +4484,7 @@ This request was captured by the browser extension's background tracker (webRequ
     return {
       content: [{
         type: 'text',
-        text: `### Chrome Extensions\n\nTotal: ${result.count}\n\n${extList}`
+        text: `### Browser Extensions\n\nTotal: ${result.count}\n\n${extList}`
       }],
       isError: false
     };
@@ -4505,7 +4505,7 @@ This request was captured by the browser extension's background tracker (webRequ
     // If user tried to reload a packed extension, explain why it didn't work
     if (skippedPacked.length > 0) {
       text += `\n\n⚠️ **Skipped (packed extensions):** ${skippedPacked.join(', ')}`;
-      text += `\n\n**Note:** Only unpacked/development extensions can be reloaded. Packed extensions (from Chrome Web Store or .crx files) must be manually updated.`;
+      text += `\n\n**Note:** Only unpacked/development extensions can be reloaded. Packed extensions (from browser web stores or package files) must be manually updated.`;
     }
 
     return {
@@ -4528,7 +4528,7 @@ This request was captured by the browser extension's background tracker (webRequ
 
     const url = pageInfo.targetInfo?.url;
     if (!url || url.startsWith('chrome://') || url.startsWith('about:')) {
-      throw new Error('Cannot get metrics for chrome:// or about:// pages. Please navigate to a web page first.');
+      throw new Error('Cannot get metrics for browser internal pages (chrome://, about://). Please navigate to a web page first.');
     }
 
     try {


### PR DESCRIPTION
## Summary
Updates all references from Chrome-specific to browser-agnostic language to accurately reflect support for multiple browsers (Chrome, Firefox, Edge, Opera).

## Changes

### Server Identity
- Server name: `"Blueprint MCP for Chrome"` → `"Blueprint MCP for Browser"`
- CLI description now lists all supported browsers: "Chrome, Firefox, Edge, Opera"

### Tool Descriptions & Messages
- `"Chrome extension"` → `"browser extension"`
- `"Chrome extensions"` → `"browser extensions"`
- `"Chrome Web Store"` → `"browser web stores"`

### Default Values
- Default browser name: `"Local Chrome"` → `"Local Browser"`
- Fallback browser name: `"Chrome"` → `"Browser"`

### User-Facing Messages
- Error messages updated to reference "browser" generically
- Instructions updated to mention all supported browsers or use "your browser"
- Multi-browser list: `"Chrome browsers"` → `"browsers"`

## Testing
- ✅ All 76 tests passing
- No functional changes, only naming/wording updates

## Impact
- More accurate representation of supported browsers
- Better UX for Firefox, Edge, and Opera users
- No breaking changes - purely cosmetic refactor