### PR TITLE
Document --port command line option

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,8 +334,12 @@ DEBUG=false
 ### Command Line Options
 
 ```bash
-blueprint-mcp --debug          # Enable verbose logging
+blueprint-mcp --debug              # Enable verbose logging
+blueprint-mcp --port 8080          # Use custom WebSocket port (default: 5555)
+blueprint-mcp --debug --port 8080  # Combine options
 ```
+
+**Note:** If you change the port, you'll need to update your browser extension settings to match.
 
 ## Troubleshooting
 
@@ -346,9 +350,16 @@ blueprint-mcp --debug          # Enable verbose logging
 4. Try reloading the extension
 
 ### "Port 5555 already in use"
-Another instance is running. Find and kill it:
+Another instance is running. You can either:
+
+1. Kill the existing process:
 ```bash
 lsof -ti:5555 | xargs kill -9
+```
+
+2. Use a different port:
+```bash
+blueprint-mcp --port 8080
 ```
 
 ### Browser tools not working


### PR DESCRIPTION
## Summary

Adds documentation for the `--port` CLI option that was previously undocumented.

## Changes

1. **Command Line Options section**
   - Added `--port` option with usage examples
   - Shows how to combine with `--debug`
   - Added note about updating browser extension settings

2. **Troubleshooting section**
   - Enhanced "Port already in use" section
   - Now suggests using custom port as alternative to killing process

## Why

The `--port` option has existed in the code (cli.js:232) but wasn't documented in the README. Users who need to run multiple instances or have port conflicts need to know about this option.

## Examples

```bash
blueprint-mcp --port 8080          # Use custom port
blueprint-mcp --debug --port 8080  # Combine options
```