### PR TITLE
Update extension manifest descriptions

### DIFF
--- a/extensions/chrome/manifest.json
+++ b/extensions/chrome/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Blueprint MCP for Chrome",
   "version": "1.9.11",
-  "description": "Share browser tabs with Blueprint MCP server",
+  "description": "Browser automation for Claude without token limits. Uses CSS selectors, not snapshots. Open source, zero telemetry.",
   "permissions": [
     "alarms",
     "debugger",

--- a/extensions/edge/manifest.json
+++ b/extensions/edge/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Blueprint MCP for Edge",
   "version": "1.9.11",
-  "description": "Edge extension for Blueprint MCP - browser automation via Model Context Protocol",
+  "description": "Browser automation for Claude without token limits. Uses CSS selectors, not snapshots. Open source, zero telemetry.",
   "permissions": [
     "alarms",
     "debugger",

--- a/extensions/firefox/manifest.json
+++ b/extensions/firefox/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Blueprint MCP for Firefox",
   "version": "1.9.11",
-  "description": "Firefox extension for Blueprint MCP - browser automation via Model Context Protocol",
+  "description": "Browser automation for Claude without token limits. Uses CSS selectors, not snapshots. Open source, zero telemetry.",
   "browser_specific_settings": {
     "gecko": {
       "id": "blueprint-mcp@railsblueprint.com"

--- a/extensions/opera/manifest.json
+++ b/extensions/opera/manifest.json
@@ -2,7 +2,7 @@
   "manifest_version": 3,
   "name": "Blueprint MCP for Opera",
   "version": "1.9.11",
-  "description": "Share browser tabs with Blueprint MCP server",
+  "description": "Browser automation for Claude without token limits. Uses CSS selectors, not snapshots. Open source, zero telemetry.",
   "permissions": [
     "alarms",
     "debugger",


### PR DESCRIPTION
## Summary

Updates the description in all browser extension manifests to better communicate Blueprint MCP's unique value propositions.

## New Description

```
Browser automation for Claude without token limits. Uses CSS selectors, not snapshots. Open source, zero telemetry.
```

## Why This Change?

The old descriptions were generic:
- Chrome/Opera: "Share browser tabs with Blueprint MCP server"
- Firefox: "Firefox extension for Blueprint MCP - browser automation via Model Context Protocol"
- Edge: "Edge extension for Blueprint MCP - browser automation via Model Context Protocol"

These didn't highlight what makes Blueprint MCP unique:

1. **Token efficiency** - CSS selectors instead of costly screenshot snapshots
2. **Privacy** - Open source with zero telemetry
3. **Use case** - Specifically designed for Claude integration

## Impact

Users browsing extension stores will immediately understand:
- Why they should use this over alternatives (token savings)
- What technology it uses (CSS selectors, not vision API)
- Privacy stance (open source, no tracking)

## Changed Files

- `extensions/chrome/manifest.json`
- `extensions/firefox/manifest.json`
- `extensions/opera/manifest.json`
- `extensions/edge/manifest.json`