### PR TITLE
Fix custom browser names not appearing in browser list

### DIFF
--- a/extensions/shared/connection/websocket.js
+++ b/extensions/shared/connection/websocket.js
@@ -507,8 +507,10 @@ export class WebSocketConnection {
       throw new Error('Authentication failed: Token expired. Please login again.');
     }
 
-    // Always get browser name from manifest (most reliable)
-    const browserName = this._getBrowserName();
+    // Get custom browser name from storage, fallback to manifest name
+    const defaultBrowserName = this._getBrowserName();
+    const storedName = await this.browser.storage.local.get(['browserName']);
+    const browserName = storedName.browserName || defaultBrowserName;
 
     // Get or generate stable client_id
     let clientId = result.stableClientId;


### PR DESCRIPTION
## Summary

- Fixed custom browser names not being sent to relay server during authentication
- Browser list now shows user-configured custom names instead of generic 'Chrome' / 'Chrome'
- Allows users to distinguish between multiple browser instances (e.g., 'Work Chrome' vs 'Personal Chrome')

## Root Cause

The WebSocket authentication handler was using `_getBrowserName()` which returns the browser type from manifest.json, instead of reading the custom `browserName` from storage that users set in extension settings.

## Changes

- Modified `extensions/shared/connection/websocket.js` authentication handler
- Now reads custom `browserName` from storage during authentication
- Falls back to manifest name if no custom name is set
- Sends custom name in auth response to relay server

## Testing

- ✅ All tests passing (76 passed, 15 skipped)
- Extension builds successfully for all browsers (Chrome, Firefox, Opera, Edge)
- Custom browser names will now appear when calling `enable` tool with multiple browsers

## Impact

PRO users can now set meaningful names for their browsers in extension settings, and those names will appear in the browser selection list when multiple browsers are connected to the relay.