### PR TITLE
Fix screenshot failures from debugger detachment

### DIFF
--- a/extensions/chrome/src/background-module.js
+++ b/extensions/chrome/src/background-module.js
@@ -345,6 +345,18 @@ chrome.runtime.onMessage.addListener((message, sender, sendResponse) => {
 // Initialize WebSocket connection
 wsConnection = new WebSocketConnection(chrome, logger, iconManager, buildTimestamp);
 
+// Listen for debugger detach events to keep state in sync
+chrome.debugger.onDetach.addListener((source, reason) => {
+  logger.log(`[Background] Debugger detached from tab ${source.tabId}, reason: ${reason}`);
+
+  // Reset debugger state if it was detached from the current tab
+  if (source.tabId === currentDebuggerTabId) {
+    debuggerAttached = false;
+    currentDebuggerTabId = null;
+    logger.log('[Background] Debugger state reset');
+  }
+});
+
 // Helper function to ensure debugger is attached to current tab
 async function ensureDebuggerAttached() {
   const attachedTabId = tabHandlers.getAttachedTabId();


### PR DESCRIPTION
## Summary

- Fixed screenshot failures caused by Chrome debugger detachment
- Added event listener to track debugger state changes
- Screenshots now automatically re-attach debugger when needed

## Problem

When the Chrome debugger gets detached from a tab, the extension wasn't tracking this state change. The `debuggerAttached` flag would remain `true` even though the actual debugger connection was gone, causing screenshot attempts to fail with errors like:

```
Screenshot failed: Debugger is not attached to the tab with id: 444321420.
```

**Common causes of debugger detachment:**
- User opens DevTools on the tab
- Navigation to certain protected pages
- Extension reload
- Tab crash or suspension

## Solution

Added a `chrome.debugger.onDetach` event listener that:
1. Detects when debugger is detached from any tab
2. Resets the `debuggerAttached` and `currentDebuggerTabId` state variables
3. Logs the detachment event for debugging

When the next screenshot is attempted, `ensureDebuggerAttached()` will see the flag is `false` and automatically re-attach the debugger.

## Changes

- Added `chrome.debugger.onDetach` event listener in `extensions/chrome/src/background-module.js`
- Reset debugger state variables on detach events
- Added logging for detachment events

## Testing

- ✅ All tests passing (76 passed, 15 skipped)
- ✅ Extension builds successfully
- ✅ Debugger state now properly synced with actual Chrome debugger connection

## Impact

Screenshots and other CDP-based operations will now work reliably even after debugger disconnections. The extension will automatically recover from detachment without requiring manual intervention.