### PR TITLE
Add welcome page on extension install

### DIFF
--- a/extensions/chrome/src/background-module.js
+++ b/extensions/chrome/src/background-module.js
@@ -16,10 +16,15 @@ import { DialogHandler } from '../../shared/handlers/dialogs.js';
 import { ConsoleHandler } from '../../shared/handlers/console.js';
 import { createBrowserAdapter } from '../../shared/adapters/browser.js';
 import { wrapWithUnwrap, shouldUnwrap } from '../../shared/utils/unwrap.js';
+import { setupInstallHandler } from '../../shared/handlers/install.js';
 
 // Initialize browser adapter at top level (before async IIFE)
 const browserAdapter = createBrowserAdapter();
 const chrome = browserAdapter.getRawAPI();
+
+// Set up welcome page to open on first install (must be at top level for MV3)
+// Browser name is auto-detected from manifest.json
+setupInstallHandler(chrome);
 
 // Top-level variables for tab monitoring
 let tabHandlers = null;

--- a/extensions/firefox/src/background-module.js
+++ b/extensions/firefox/src/background-module.js
@@ -16,13 +16,18 @@ import { DialogHandler } from '../shared/handlers/dialogs.js';
 import { ConsoleHandler } from '../shared/handlers/console.js';
 import { createBrowserAdapter } from '../shared/adapters/browser.js';
 import { wrapWithUnwrap, shouldUnwrap } from '../shared/utils/unwrap.js';
+import { setupInstallHandler } from '../shared/handlers/install.js';
+
+// Initialize browser adapter at top level (before async IIFE) for install handler
+const browserAdapter = createBrowserAdapter();
+const browser = browserAdapter.getRawAPI();
+
+// Set up welcome page to open on first install (must be at top level)
+// Browser name is auto-detected from manifest.json
+setupInstallHandler(browser);
 
 // Main initialization
 (async () => {
-
-// Initialize browser adapter
-const browserAdapter = createBrowserAdapter();
-const browser = browserAdapter.getRawAPI();
 
 /**
  * Execute script helper - Manifest V3 compatible

--- a/extensions/shared/handlers/install.js
+++ b/extensions/shared/handlers/install.js
@@ -1,0 +1,49 @@
+/**
+ * Install handler - opens welcome page on first install
+ *
+ * Usage:
+ *   import { setupInstallHandler } from '../shared/handlers/install.js';
+ *   setupInstallHandler(chrome);
+ *
+ * Browser name is auto-detected from manifest.json extension name
+ * e.g., "Blueprint MCP for Chrome" -> "chrome"
+ */
+
+// Welcome page base URL - each browser version points here with browser param
+const WELCOME_URL_BASE = 'https://blueprint-mcp.railsblueprint.com/welcome';
+
+/**
+ * Extract browser name from extension manifest name
+ * "Blueprint MCP for Chrome" -> "chrome"
+ * "Blueprint MCP for Firefox" -> "firefox"
+ *
+ * @param {object} browserAPI - The browser API
+ * @returns {string} Browser name in lowercase
+ */
+function getBrowserNameFromManifest(browserAPI) {
+  const manifest = browserAPI.runtime.getManifest();
+  const extensionName = manifest.name || '';
+  // Match "Blueprint MCP for X" pattern
+  const match = extensionName.match(/Blueprint MCP for (\w+)/i);
+  if (match) {
+    return match[1].toLowerCase();
+  }
+  // Fallback to 'unknown' if pattern doesn't match
+  return 'unknown';
+}
+
+/**
+ * Set up the onInstalled handler to open welcome page on first install
+ *
+ * @param {object} browserAPI - The browser API (chrome or browser)
+ */
+export function setupInstallHandler(browserAPI) {
+  browserAPI.runtime.onInstalled.addListener((details) => {
+    // Only open welcome page on fresh install, not on updates or browser updates
+    if (details.reason === 'install') {
+      const browserName = getBrowserNameFromManifest(browserAPI);
+      const welcomeUrl = `${WELCOME_URL_BASE}?browser=${encodeURIComponent(browserName)}`;
+      browserAPI.tabs.create({ url: welcomeUrl });
+    }
+  });
+}


### PR DESCRIPTION
## Summary
- Opens welcome page when extension is freshly installed
- URL: `https://blueprint-mcp.railsblueprint.com/welcome?browser={browser}`
- Browser name auto-detected from manifest (chrome, firefox, opera, edge)

## Test plan
- [ ] Install extension fresh in Chrome, verify welcome page opens with `?browser=chrome`
- [ ] Install extension fresh in Firefox, verify welcome page opens with `?browser=firefox`
- [ ] Build Opera/Edge extensions, verify they include the install handler