### PR TITLE
Fix Firefox service worker suspension causing popup errors

### DIFF
--- a/extensions/firefox/manifest.json
+++ b/extensions/firefox/manifest.json
@@ -16,7 +16,8 @@
     "webRequest",
     "storage",
     "management",
-    "scripting"
+    "scripting",
+    "alarms"
   ],
   "host_permissions": [
     "<all_urls>",

--- a/extensions/firefox/src/background-module.js
+++ b/extensions/firefox/src/background-module.js
@@ -26,6 +26,17 @@ const browser = browserAdapter.getRawAPI();
 // Browser name is auto-detected from manifest.json
 setupInstallHandler(browser);
 
+// Set up keepalive alarm at TOP LEVEL (prevents service worker suspension in MV3)
+// This must be synchronous to ensure the listener is registered before service worker sleeps
+if (browser.alarms) {
+  browser.alarms.create('keepalive', { periodInMinutes: 1 });
+  browser.alarms.onAlarm.addListener((alarm) => {
+    if (alarm.name === 'keepalive') {
+      console.log('[Background] Keepalive alarm - service worker active');
+    }
+  });
+}
+
 // Main initialization
 (async () => {
 


### PR DESCRIPTION
## Summary
- Add keepalive alarm to Firefox extension to prevent service worker suspension
- In PRO mode, clicking the Firefox extension icon sometimes showed "Receiving end does not exist" error
- Root cause: service worker was suspended before the popup could communicate with it

## Changes
- Add `alarms` permission to Firefox manifest
- Add keepalive alarm at top level (synchronous) to prevent service worker suspension
- Matches Chrome extension behavior which already had this fix

## Test plan
- [ ] Load Firefox extension from `dist/firefox/`
- [ ] Enable PRO mode
- [ ] Wait a few minutes for service worker to potentially suspend
- [ ] Click extension icon - should not show "Receiving end does not exist" error
- [ ] Check browser console for "Keepalive alarm - service worker active" messages every minute