### PR TITLE
Make :has-text() selector fully case-insensitive

### DIFF
--- a/server/src/unifiedBackend.js
+++ b/server/src/unifiedBackend.js
@@ -1390,7 +1390,7 @@ class UnifiedBackend {
         const elements = document.querySelectorAll(baseSelector);
         for (const el of elements) {
           const text = el.textContent || el.innerText || '';
-          if (text.includes(searchText)) {
+          if (text.toLowerCase().includes(searchText.toLowerCase())) {
             // If there's a remainder selector, find the descendant element
             if (remainderSelector) {
               const target = el.querySelector(remainderSelector);


### PR DESCRIPTION
## Summary
- Fix inconsistent case sensitivity in `:has-text()` pseudo-selector
- `_findAllElements` was already case-insensitive, but `_getSelectorExpression` was case-sensitive
- Now both use `toLowerCase()` for consistent behavior

## Example
```javascript
// Now matches "SUBMIT", "Submit", "submit", etc.
button:has-text("Submit")
```

## Test plan
- [ ] Test `button:has-text("submit")` matches button with text "SUBMIT"
- [ ] Test `button:has-text("CLICK")` matches button with text "Click Here"
- [ ] Run server tests