### PR TITLE
Add script mode for non-MCP scripting (PRO feature)

### DIFF
--- a/server/cli.js
+++ b/server/cli.js
@@ -32,6 +32,7 @@ const { PassThrough } = require('stream');
 const { getLogger } = require('./src/fileLogger');
 
 const packageJSON = require('./package.json');
+const { startScriptMode } = require('./src/scriptMode');
 
 // Simple config resolver
 function resolveConfig(options) {
@@ -231,7 +232,15 @@ program
   .option('--log-file <path>', 'Custom log file path (default: logs/mcp-debug.log)')
   .option('--port <number>', 'WebSocket server port (default: 5555)', parseInt)
   .option('--child', 'Internal flag: indicates this is a child process spawned by wrapper')
+  .option('--script-mode', 'Enable scripting mode (JSON-RPC over stdio for automation scripts)')
   .action(async (options) => {
+    // Script mode: JSON-RPC over stdio for automation scripts
+    if (options.scriptMode) {
+      const config = resolveConfig(options);
+      await startScriptMode(config);
+      return;
+    }
+
     // If --debug and NOT --child: run as wrapper (parent process)
     if (options.debug && !options.child) {
       runAsWrapper();

--- a/server/src/scriptMode.js
+++ b/server/src/scriptMode.js
@@ -1,0 +1,160 @@
+/**
+ * Script Mode (PRO feature)
+ *
+ * Provides a simple JSON-RPC 2.0 interface over stdin/stdout for scripting.
+ * Allows any language (Python, Ruby, Bash, etc.) to control the browser
+ * without needing MCP client libraries.
+ *
+ * REQUIRES: PRO authentication (OAuth tokens)
+ *
+ * Protocol:
+ * - One JSON message per line (request or batch array)
+ * - Responses are returned as JSON lines
+ * - Server exits when stdin closes
+ *
+ * Example:
+ *   Input:  {"jsonrpc":"2.0","id":1,"method":"enable","params":{"client_id":"my-script"}}
+ *   Output: {"jsonrpc":"2.0","id":1,"result":{"success":true,"mode":"pro","state":"active"}}
+ */
+
+const readline = require('readline');
+const { StatefulBackend } = require('./statefulBackend');
+const { OAuth2Client } = require('./oauth');
+
+/**
+ * Start script mode - JSON-RPC over stdio (PRO only)
+ */
+async function startScriptMode(config) {
+  // Check PRO authentication first
+  const oauth = new OAuth2Client(config);
+  const isAuthenticated = await oauth.isAuthenticated();
+
+  if (!isAuthenticated) {
+    // Output error and exit
+    const errorResponse = {
+      jsonrpc: '2.0',
+      id: null,
+      error: {
+        code: -32001,
+        message: 'Script mode requires PRO authentication. Run "npx @railsblueprint/blueprint-mcp auth login" first, or visit https://blueprint-mcp.railsblueprint.com/pro'
+      }
+    };
+    console.log(JSON.stringify(errorResponse));
+    process.exit(1);
+  }
+
+  // Create backend
+  const backend = new StatefulBackend(config);
+
+  // Initialize backend (no MCP server needed)
+  await backend.initialize(null, {});
+
+  // Create readline interface
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+    terminal: false
+  });
+
+  // Process incoming lines
+  rl.on('line', async (line) => {
+    try {
+      const trimmed = line.trim();
+      if (!trimmed) return; // Skip empty lines
+
+      const parsed = JSON.parse(trimmed);
+
+      // Handle batch requests (array)
+      if (Array.isArray(parsed)) {
+        const results = await Promise.all(
+          parsed.map(req => handleRequest(req, backend))
+        );
+        console.log(JSON.stringify(results));
+      } else {
+        // Single request
+        const result = await handleRequest(parsed, backend);
+        console.log(JSON.stringify(result));
+      }
+    } catch (error) {
+      // JSON parse error
+      const errorResponse = {
+        jsonrpc: '2.0',
+        id: null,
+        error: {
+          code: -32700, // Parse error
+          message: `Parse error: ${error.message}`
+        }
+      };
+      console.log(JSON.stringify(errorResponse));
+    }
+  });
+
+  // Clean shutdown when stdin closes
+  rl.on('close', async () => {
+    await backend.serverClosed();
+    process.exit(0);
+  });
+
+  // Handle signals
+  process.on('SIGINT', async () => {
+    await backend.serverClosed();
+    process.exit(0);
+  });
+
+  process.on('SIGTERM', async () => {
+    await backend.serverClosed();
+    process.exit(0);
+  });
+}
+
+/**
+ * Handle a single JSON-RPC request
+ */
+async function handleRequest(request, backend) {
+  const { jsonrpc, id, method, params } = request;
+
+  // Validate JSON-RPC format
+  if (jsonrpc !== '2.0') {
+    return {
+      jsonrpc: '2.0',
+      id: id || null,
+      error: {
+        code: -32600, // Invalid Request
+        message: 'Invalid JSON-RPC version (must be "2.0")'
+      }
+    };
+  }
+
+  if (!method || typeof method !== 'string') {
+    return {
+      jsonrpc: '2.0',
+      id: id || null,
+      error: {
+        code: -32600,
+        message: 'Missing or invalid method'
+      }
+    };
+  }
+
+  try {
+    // Call the tool with rawResult option for structured responses
+    const result = await backend.callTool(method, params || {}, { rawResult: true });
+
+    return {
+      jsonrpc: '2.0',
+      id,
+      result
+    };
+  } catch (error) {
+    return {
+      jsonrpc: '2.0',
+      id,
+      error: {
+        code: -32000, // Server error
+        message: error.message || String(error)
+      }
+    };
+  }
+}
+
+module.exports = { startScriptMode };

--- a/server/src/wrappers/index.js
+++ b/server/src/wrappers/index.js
@@ -1,0 +1,153 @@
+/**
+ * Wrapper Generator
+ *
+ * Generates language-specific wrappers for Blueprint MCP script mode.
+ * Methods are dynamically generated from the tool list.
+ */
+
+const python = require('./python');
+const javascript = require('./javascript');
+const ruby = require('./ruby');
+
+const wrappers = {
+  python,
+  javascript,
+  ruby
+};
+
+/**
+ * Generate a complete wrapper for the given language
+ * @param {string} language - 'python', 'javascript', or 'ruby'
+ * @param {Array} tools - Array of tool definitions from listTools()
+ * @returns {string} Complete wrapper code
+ */
+function generateWrapper(language, tools) {
+  const wrapper = wrappers[language];
+  if (!wrapper) {
+    throw new Error(`Unknown language: ${language}. Available: ${Object.keys(wrappers).join(', ')}`);
+  }
+
+  // Filter to tools that should be exposed in scripts
+  // Exclude 'scripting' itself to avoid recursion
+  const scriptableTools = tools.filter(t => t.name !== 'scripting');
+
+  // Generate method code for each tool
+  const methods = scriptableTools
+    .map(tool => wrapper.generateMethod(tool.name))
+    .join('\n');
+
+  // Replace placeholder in template
+  return wrapper.template.replace('{{METHODS}}', methods);
+}
+
+/**
+ * Get list of available wrapper languages
+ * @returns {string[]}
+ */
+function getAvailableLanguages() {
+  return Object.keys(wrappers);
+}
+
+/**
+ * Get file extension for a language
+ * @param {string} language
+ * @returns {string}
+ */
+function getFileExtension(language) {
+  const extensions = {
+    python: '.py',
+    javascript: '.mjs',
+    ruby: '.rb'
+  };
+  return extensions[language] || '';
+}
+
+/**
+ * Get usage instructions text
+ * @param {Array} tools - Array of tool definitions
+ * @returns {string}
+ */
+function getInstructions(tools) {
+  const toolNames = tools
+    .filter(t => t.name !== 'scripting')
+    .map(t => t.name)
+    .join(', ');
+
+  return `## Blueprint MCP Scripting
+
+Automate browser tasks with external scripts. Use when page structure and selectors are known.
+
+### How It Works
+1. Install a wrapper file for your language
+2. Import the wrapper in your script
+3. Call methods that match tool names exactly
+
+### Available Wrappers
+- **python** - Python 3 wrapper
+- **javascript** - Node.js ES module wrapper
+- **ruby** - Ruby wrapper
+
+### Install a Wrapper
+\`\`\`
+scripting action='install_wrapper' language='python' path='./blueprint_mcp.py'
+\`\`\`
+
+### Available Methods
+All tool names become methods: ${toolNames}
+
+### Usage Example (Python)
+\`\`\`python
+from blueprint_mcp import BlueprintMCP
+
+bp = BlueprintMCP()
+bp.enable(client_id='my-script')
+
+# List tabs
+tabs = bp.browser_tabs(action='list')
+print(tabs['tabs'])
+
+# Navigate
+bp.browser_navigate(action='url', url='https://example.com')
+
+# Interact
+bp.browser_interact(actions=[{'type': 'click', 'selector': 'button'}])
+
+bp.close()
+\`\`\`
+
+### Usage Example (JavaScript)
+\`\`\`javascript
+import { BlueprintMCP } from './blueprint_mcp.mjs';
+
+const bp = new BlueprintMCP();
+await bp.enable({ client_id: 'my-script' });
+
+const tabs = await bp.browser_tabs({ action: 'list' });
+console.log(tabs.tabs);
+
+await bp.browser_navigate({ action: 'url', url: 'https://example.com' });
+bp.close();
+\`\`\`
+
+### Usage Example (Ruby)
+\`\`\`ruby
+require_relative 'blueprint_mcp'
+
+bp = BlueprintMCP.new
+bp.enable(client_id: 'my-script')
+
+tabs = bp.browser_tabs(action: 'list')
+puts tabs['tabs']
+
+bp.browser_navigate(action: 'url', url: 'https://example.com')
+bp.close
+\`\`\`
+`;
+}
+
+module.exports = {
+  generateWrapper,
+  getAvailableLanguages,
+  getFileExtension,
+  getInstructions
+};

--- a/server/src/wrappers/javascript.js
+++ b/server/src/wrappers/javascript.js
@@ -1,0 +1,112 @@
+/**
+ * JavaScript Wrapper Template
+ */
+
+const template = `/**
+ * Blueprint MCP Wrapper for JavaScript
+ *
+ * Auto-generated wrapper for Blueprint MCP script mode.
+ * Methods match tool names exactly for easy code generation.
+ *
+ * Usage:
+ *   import { BlueprintMCP } from './blueprint_mcp.mjs';
+ *
+ *   const bp = new BlueprintMCP();
+ *   await bp.enable({ client_id: 'my-script' });
+ *   const tabs = await bp.browser_tabs({ action: 'list' });
+ *   bp.close();
+ */
+
+import { spawn } from 'child_process';
+import { createInterface } from 'readline';
+
+export class BlueprintMCP {
+  #proc = null;
+  #rl = null;
+  #id = 0;
+  #debug = false;
+  #pending = new Map();
+
+  /**
+   * Initialize Blueprint MCP client.
+   * @param {Object} options
+   * @param {boolean} options.debug - Enable debug output
+   */
+  constructor(options = {}) {
+    this.#debug = options.debug || false;
+
+    this.#proc = spawn('npx', ['@railsblueprint/blueprint-mcp', '--script-mode'], {
+      stdio: ['pipe', 'pipe', this.#debug ? 'inherit' : 'ignore']
+    });
+
+    this.#rl = createInterface({
+      input: this.#proc.stdout,
+      terminal: false
+    });
+
+    this.#rl.on('line', (line) => {
+      if (this.#debug) console.error('[BlueprintMCP] <-', line);
+
+      try {
+        const response = JSON.parse(line);
+        if (response.id && this.#pending.has(response.id)) {
+          const { resolve, reject } = this.#pending.get(response.id);
+          this.#pending.delete(response.id);
+
+          if (response.error) {
+            reject(new Error(response.error.message || 'Unknown error'));
+          } else {
+            resolve(response.result);
+          }
+        }
+      } catch (e) {
+        console.error('[BlueprintMCP] Parse error:', e);
+      }
+    });
+  }
+
+  async _call(method, params = {}) {
+    const id = ++this.#id;
+    const request = { jsonrpc: '2.0', id, method, params };
+
+    if (this.#debug) console.error('[BlueprintMCP] ->', JSON.stringify(request));
+
+    return new Promise((resolve, reject) => {
+      this.#pending.set(id, { resolve, reject });
+      this.#proc.stdin.write(JSON.stringify(request) + '\\n');
+    });
+  }
+
+  // Auto-generated methods (match tool names exactly)
+{{METHODS}}
+
+  close() {
+    if (this.#proc) {
+      try {
+        this.#proc.stdin.end();
+        this.#proc.kill();
+      } catch (e) {
+        // Ignore
+      }
+      this.#proc = null;
+    }
+  }
+}
+`;
+
+/**
+ * Generate a JavaScript method for a tool
+ * @param {string} toolName - Tool name (e.g., 'browser_tabs')
+ * @returns {string} JavaScript method code
+ */
+function generateMethod(toolName) {
+  return `  async ${toolName}(params = {}) {
+    return this._call('${toolName}', params);
+  }
+`;
+}
+
+module.exports = {
+  template,
+  generateMethod
+};

--- a/server/src/wrappers/python.js
+++ b/server/src/wrappers/python.js
@@ -1,0 +1,113 @@
+/**
+ * Python Wrapper Template
+ */
+
+const template = `#!/usr/bin/env python3
+"""
+Blueprint MCP Wrapper for Python
+
+Auto-generated wrapper for Blueprint MCP script mode.
+Methods match tool names exactly for easy code generation.
+
+Usage:
+    from blueprint_mcp import BlueprintMCP
+
+    bp = BlueprintMCP()
+    bp.enable(client_id='my-script')
+    tabs = bp.browser_tabs(action='list')
+    bp.close()
+"""
+
+import subprocess
+import json
+import sys
+
+
+class BlueprintMCP:
+    """Blueprint MCP client for Python scripts."""
+
+    def __init__(self, debug=False):
+        """
+        Initialize Blueprint MCP client.
+
+        Args:
+            debug: Enable debug output to stderr
+        """
+        self._debug = debug
+        self._id = 0
+        self._proc = subprocess.Popen(
+            ['npx', '@railsblueprint/blueprint-mcp', '--script-mode'],
+            stdin=subprocess.PIPE,
+            stdout=subprocess.PIPE,
+            stderr=None if debug else subprocess.DEVNULL,
+            text=True,
+            bufsize=1
+        )
+
+    def _call(self, method, **params):
+        """Send a JSON-RPC request and return the result."""
+        self._id += 1
+        request = {
+            'jsonrpc': '2.0',
+            'id': self._id,
+            'method': method,
+            'params': params
+        }
+
+        if self._debug:
+            print(f'[BlueprintMCP] -> {json.dumps(request)}', file=sys.stderr)
+
+        self._proc.stdin.write(json.dumps(request) + '\\n')
+        self._proc.stdin.flush()
+
+        response_line = self._proc.stdout.readline()
+        if not response_line:
+            raise RuntimeError('No response from server')
+
+        if self._debug:
+            print(f'[BlueprintMCP] <- {response_line.strip()}', file=sys.stderr)
+
+        response = json.loads(response_line)
+
+        if 'error' in response:
+            raise RuntimeError(response['error'].get('message', 'Unknown error'))
+
+        return response.get('result')
+
+    # Auto-generated methods (match tool names exactly)
+{{METHODS}}
+
+    def close(self):
+        """Close the connection and terminate the server."""
+        if self._proc:
+            try:
+                self._proc.stdin.close()
+                self._proc.terminate()
+                self._proc.wait(timeout=5)
+            except Exception:
+                self._proc.kill()
+            self._proc = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *args):
+        self.close()
+        return False
+`;
+
+/**
+ * Generate a Python method for a tool
+ * @param {string} toolName - Tool name (e.g., 'browser_tabs')
+ * @returns {string} Python method code
+ */
+function generateMethod(toolName) {
+  return `    def ${toolName}(self, **params):
+        return self._call('${toolName}', **params)
+`;
+}
+
+module.exports = {
+  template,
+  generateMethod
+};

--- a/server/src/wrappers/ruby.js
+++ b/server/src/wrappers/ruby.js
@@ -1,0 +1,96 @@
+/**
+ * Ruby Wrapper Template
+ */
+
+const template = `#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+#
+# Blueprint MCP Wrapper for Ruby
+#
+# Auto-generated wrapper for Blueprint MCP script mode.
+# Methods match tool names exactly for easy code generation.
+#
+# Usage:
+#   require_relative 'blueprint_mcp'
+#
+#   bp = BlueprintMCP.new
+#   bp.enable(client_id: 'my-script')
+#   tabs = bp.browser_tabs(action: 'list')
+#   bp.close
+#
+
+require 'json'
+require 'open3'
+
+class BlueprintMCP
+  def initialize(debug: false)
+    @debug = debug
+    @id = 0
+    @stdin, @stdout, @stderr, @wait_thr = Open3.popen3(
+      'npx', '@railsblueprint/blueprint-mcp', '--script-mode'
+    )
+  end
+
+  def _call(method, **params)
+    @id += 1
+    request = {
+      jsonrpc: '2.0',
+      id: @id,
+      method: method,
+      params: params
+    }
+
+    warn "[BlueprintMCP] -> #{request.to_json}" if @debug
+
+    @stdin.puts(request.to_json)
+    @stdin.flush
+
+    response_line = @stdout.gets
+    raise 'No response from server' unless response_line
+
+    warn "[BlueprintMCP] <- #{response_line.strip}" if @debug
+
+    response = JSON.parse(response_line, symbolize_names: true)
+
+    raise response[:error][:message] || 'Unknown error' if response[:error]
+
+    response[:result]
+  end
+
+  # Auto-generated methods (match tool names exactly)
+{{METHODS}}
+
+  def close
+    return unless @stdin
+
+    begin
+      @stdin.close
+      @stdout.close
+      @stderr.close
+      Process.kill('TERM', @wait_thr.pid)
+    rescue StandardError
+      # Ignore cleanup errors
+    end
+
+    @stdin = nil
+  end
+end
+`;
+
+/**
+ * Generate a Ruby method for a tool
+ * @param {string} toolName - Tool name (e.g., 'browser_tabs')
+ * @returns {string} Ruby method code
+ */
+function generateMethod(toolName) {
+  return `  def ${toolName}(**params)
+    _call('${toolName}', **params)
+  end
+`;
+}
+
+module.exports = {
+  template,
+  generateMethod
+};


### PR DESCRIPTION
## Summary
- Add `--script-mode` CLI flag for JSON-RPC 2.0 over stdin/stdout
- Require PRO authentication for script mode (exits with error if not authenticated)
- Add `rawResult` option to all tool handlers for structured JSON responses
- Add language wrapper templates (Python, JavaScript, Ruby) accessible via `scripting` tool
- Include `scripting` tool for discovery in MCP mode

## Details

### Script Mode
Allows any programming language to control the browser using simple JSON-RPC 2.0 over stdin/stdout:
```bash
node cli.js --script-mode
```

### rawResult Option
All tool handlers now support `rawResult: true` option to return structured JSON instead of MCP markdown format. This is essential for scripting where parsable responses are needed.

### Language Wrappers
Template wrappers provided for:
- Python (BlueprintMCP class)
- JavaScript (Node.js subprocess spawning)
- Ruby (JSON-RPC client)

## Test plan
- [x] All 76 unit tests pass
- [ ] Manual test: Run YC scraper script with script mode
- [ ] Manual test: Verify PRO authentication check works