### PR TITLE
Add content security policy to manifest.json

### DIFF
--- a/extensions/firefox/manifest.json
+++ b/extensions/firefox/manifest.json
@@ -56,5 +56,8 @@
     "32": "icons/icon-32.png",
     "48": "icons/icon-48.png",
     "96": "icons/icon-96.png"
+  },
+    "content_security_policy": {
+    "extension_pages": "default-src 'self'; connect-src ws://127.0.0.1:* wss://* https://* http://127.0.0.1:*;"
   }
 }


### PR DESCRIPTION
For firefox you need to set CSP since you are mixing nonSSL and SSL connections.

## Description

Firefox's default Content Security Policy for Manifest V3 extensions automatically upgrades insecure WebSocket connections (ws://) to secure ones (wss://). This caused the extension to fail when connecting to the local MCP server at ws://127.0.0.1:5555 since the server doesn't have a TLS certificate.

Added an explicit CSP that allows ws://127.0.0.1:* connections, preventing the automatic upgrade to wss://.

Fixes # (issue)

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Ran mcp-server as supposed via claude-desktop and npx
Installed Firefox extension via local-dev as temporary addon.

- [ ] Smoke tests pass (`npm test`)
- [x] Manual testing performed
- [ ] Tested in MCP client (Claude Desktop, Cursor, etc.)
- [ ] Tested extension in Chrome

**Test Configuration**:
* Node version: 25
* Chrome version:
* OS: Win11

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published

## Screenshots (if appropriate):

## Additional Notes:
