### PR TITLE
Improve 'browser_evaluate' for async expressions

### DIFF
--- a/extensions/chrome/src/background-module.js
+++ b/extensions/chrome/src/background-module.js
@@ -524,7 +524,8 @@ async function handleCDPCommand(cdpMethod, cdpParams) {
           'Runtime.evaluate',
           {
             expression: expression,
-            returnByValue: true
+            returnByValue: cdpParams.returnByValue ?? true,
+            awaitPromise: cdpParams.awaitPromise
           }
         );
 

--- a/server/src/unifiedBackend.js
+++ b/server/src/unifiedBackend.js
@@ -312,8 +312,13 @@ class UnifiedBackend {
           type: 'object',
           properties: {
             function: { type: 'string', description: 'JavaScript function to execute' },
-            expression: { type: 'string', description: 'JavaScript expression to evaluate' }
-          }
+            expression: { type: 'string', description: 'JavaScript expression to evaluate' },
+            timeout: { type: 'integer', minimum: 0, description: 'Terminate execution after timing out (number of milliseconds)' }
+          },
+          oneOf: [
+            { required: ['function'] },
+            { required: ['expression'] }
+          ]
         }
       },
 
@@ -3589,13 +3594,28 @@ class UnifiedBackend {
 
   async _handleEvaluate(args, options = {}) {
     const expression = args.function || args.expression;
+    const timeout = args.timeout;
+
+    // It is better to use a wrapper than the standard `timeout` parameter 
+    // of the `Runtime.evaluate`, because when this parameter is enabled, 
+    // Chrome simply returns `undefined` without any warnings.
+    const withTimeout = (expression, timeout) => `
+      Promise.race([
+        (${expression}),
+        new Promise((_, reject) => setTimeout(() => reject('Rejected due to timeout (${timeout} ms).'), ${timeout}))
+      ])
+    `;
 
     // If expression looks like a function definition, wrap and call it
     // Match: () => ..., function() {...}, async () => ..., etc.
-    const isFunctionExpression = /^\s*(async\s+)?\([^)]*\)\s*=>|^\s*function\s*\(/.test(expression);
+    const isFunctionExpression = /^\s*(async\s*)?(\([^)]*\)|[_$a-z][_$a-z0-9]*)\s*=>|^\s*(async\s+)?function\s*([_$a-z][_$a-z0-9]*)?\s*(\s*\*?)\s*\(/i.test(expression);
     const finalExpression = (args.function || isFunctionExpression)
-      ? `(${expression})()`
-      : expression;
+      ? typeof timeout === 'number'
+        ? withTimeout(`(${expression})()`, timeout)
+        : `(${expression})()`
+      : typeof timeout === 'number'
+        ? withTimeout(expression, timeout)
+        : expression;
 
     const result = await this._transport.sendCommand('forwardCDPCommand', {
       method: 'Runtime.evaluate',

--- a/server/tests/helpers/mocks.js
+++ b/server/tests/helpers/mocks.js
@@ -134,6 +134,26 @@ function createMockSnapshot() {
   };
 }
 
+async function mockCDPCommandRuntimeEvaluate({ params: { expression, awaitPromise } }) {
+  try {
+    return {
+      success: true,
+      result: {
+        value: awaitPromise ? await eval(expression) : eval(expression)
+      }
+    };
+  } catch (exception) {
+    return {
+      success: false,
+      exceptionDetails: {
+        exception,
+        text: typeof exception === 'string' ? exception : exception?.message ?? 'Unknown JavaScript exception',
+        stackTrace: exception?.stack,
+      }
+    };
+  }
+}
+
 module.exports = {
   createMockServer,
   createMockTransport,
@@ -144,5 +164,6 @@ module.exports = {
   createMockBrowserList,
   createMockTabList,
   createMockNetworkRequest,
-  createMockSnapshot
+  createMockSnapshot,
+  mockCDPCommandRuntimeEvaluate
 };

--- a/server/tests/unit/unifiedBackend.test.js
+++ b/server/tests/unit/unifiedBackend.test.js
@@ -1,3 +1,6 @@
+const { UnifiedBackend } = require('../../src/unifiedBackend');
+const { createMockTransport, mockCDPCommandRuntimeEvaluate } = require('../helpers/mocks')
+
 /**
  * Unit tests for UnifiedBackend - Selector Escaping
  *
@@ -132,6 +135,190 @@ describe('UnifiedBackend - Selector Escaping', () => {
       expect(() => {
         eval(code);
       }).not.toThrow();
+    });
+  });
+});
+
+describe('UnifiedBackend - _handleEvaluate()', () => {
+  const evalOptions = {
+    rawResult: true
+  };
+  let unifiedBackend;
+
+  beforeAll(() => {
+    jest.useFakeTimers()
+  });
+
+  afterAll(() => {
+    jest.useRealTimers()
+  });
+
+  beforeEach(async () => {
+    const mockTransport = {
+      ...createMockTransport(),
+      sendCommand: jest.fn(async (_, params) => {
+        return await mockCDPCommandRuntimeEvaluate(params)
+      })
+    };
+
+    unifiedBackend = new UnifiedBackend({ debug: false }, mockTransport);
+  });
+
+  test('handles expression that returns a primitive value', async () => {
+    const result = await unifiedBackend._handleEvaluate(
+      {
+        expression: `40 + 2`
+      },
+      evalOptions
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.value).toStrictEqual(42);
+  });
+
+  test('handles expression that returns an object', async () => {
+    const result = await unifiedBackend._handleEvaluate(
+      {
+        expression: `({ prop: 40 + 2 })`
+      },
+      evalOptions
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.value).toStrictEqual({ prop: 42 });
+  })
+
+  test('handles traditional function', async () => {
+    const result = await unifiedBackend._handleEvaluate(
+      {
+        function: `
+          function () {
+            return { prop: 40 + 2 };
+          }
+        `
+      },
+      evalOptions
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.value).toStrictEqual({ prop: 42 });
+  })
+
+  test('handles arrow function', async () => {
+    const result = await unifiedBackend._handleEvaluate(
+      {
+        function: `() => ({ prop: 40 + 2 })`
+      },
+      evalOptions
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.value).toStrictEqual({ prop: 42 });
+  });
+
+  test('handles traditional async function', async () => {
+    const result = await unifiedBackend._handleEvaluate(
+      {
+        function: `
+          async function () {
+            return { prop: 40 + 2 };
+          }
+        `
+      },
+      evalOptions
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.value).toStrictEqual({ prop: 42 });
+  });
+
+  test('handles arrow async function', async () => {
+    const result = await unifiedBackend._handleEvaluate(
+      {
+        function: `async () => ({ prop: 40 + 2 })`
+      },
+      evalOptions
+    );
+
+    expect(result.success).toBe(true);
+    expect(result.value).toStrictEqual({ prop: 42 });
+  });
+
+  describe('handles function expression as a function', () => {
+    const functionExpressions = [
+      'function() { return { prop: 40 + 2 } }',
+      'function () { return { prop: 40 + 2 } }',
+      'function xyz() { return { prop: 40 + 2 } }',
+      '() => ({ prop: 40 + 2 })',
+      'async() => ({ prop: 40 + 2 })',
+      'async() =>({ prop: 40 + 2 })',
+      'async _param => ({ prop: 40 + 2 })',
+      'async _param=> ({ prop: 40 + 2 })',
+      'async () => ({ prop: 40 + 2 })',
+      'async () =>({ prop: 40 + 2 })',
+      `
+        function () {
+          return { prop: 40 + 2 }
+        }
+      `
+    ];
+
+    for (const functionExpression of functionExpressions) {
+      test(`expression: '${functionExpression}'`, async () => {
+        const result = await unifiedBackend._handleEvaluate(
+          { expression: functionExpression },
+          evalOptions
+        );
+
+        expect(result.success).toBe(true);
+        expect(result.value).toStrictEqual({ prop: 42 });
+      });
+    }
+  });
+
+  describe('handles function with timeout', () => {
+    test('success case', async () => {
+      const timeout = 200;
+      const duration = 100;
+
+      const promise = unifiedBackend._handleEvaluate(
+        {
+          expression: `
+            new Promise(resolve => setTimeout(() => resolve(42), ${duration}))
+          `,
+          timeout
+        },
+        evalOptions
+      );
+
+      jest.runAllTimers();
+      const result = await promise;
+  
+      jest.runAllTimers();
+      expect(result.success).toBe(true);
+      expect(result.value).toBe(42);
+    });
+
+    test('timeout case', async () => {
+      const timeout = 100;
+      const duration = 200;
+  
+      const promise = unifiedBackend._handleEvaluate(
+        {
+          expression: `
+            new Promise(resolve => setTimeout(() => resolve(42), ${duration}))
+          `,
+          timeout
+        },
+        evalOptions
+      );
+
+      jest.runAllTimers();
+      const result = await promise;
+  
+      expect(result.success).toBe(false);
+      expect(result.message).toContain('timeout');
+      expect(result.message).toContain(String(timeout));
     });
   });
 });


### PR DESCRIPTION
## Description

Improve 'browser_evaluate' for async expressions.

Changes to Chrome extension:
* 'Runtime.evaluate' accepts and forwards 'returnByValue' and 'awaitPromise' parameters.

Changes to UnifiedBackend:
* Better detection of function expression;
* Add 'timeout' for async calls.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

- [x] Smoke tests pass (`npm test`)
- [x] Manual testing performed
- [x] Tested in MCP client (Claude Desktop, Cursor, etc.)
- [x] Tested extension in Chrome

**Test Configuration**:
* Node version: v24.14.1
* Chrome version: 146.0.7680.155 (Official Build) (arm64)
* OS: macOS 26.3.1 (25D2128)

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] No corresponding changes to the documentation are required
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published
