### PR TITLE
Fix Firefox extension stuck at "Connecting" to local MCP server

### DIFF
--- a/extensions/firefox/manifest.json
+++ b/extensions/firefox/manifest.json
@@ -24,6 +24,9 @@
     "*://*.railsblueprint.com/*",
     "*://*.blueprintmcp.com/*"
   ],
+  "content_security_policy": {
+    "extension_pages": "default-src 'self'; connect-src ws://127.0.0.1:* wss://* https://* http://127.0.0.1:*;"
+  },
   "background": {
     "scripts": [
       "src/background-module.js"


### PR DESCRIPTION
Fixes #31

## Problem

The Firefox extension status hangs at "Connecting..." and never connects to the local MCP server. The Chrome extension works fine.

## Root cause

Firefox's default Content Security Policy for Manifest V3 extensions automatically upgrades insecure WebSocket connections (`ws://`) to secure ones (`wss://`). In Free mode, the extension connects to `ws://127.0.0.1:5555/extension`, which has no TLS certificate, so the WebSocket never opens.

This was diagnosed by @chgayot in the issue thread — the Firefox console shows:
```
Content-Security-Policy: Upgrading insecure request 'ws://127.0.0.1:5555/extension' to use 'wss'
Firefox can't establish a connection to the server at wss://127.0.0.1:5555/extension
```

## Fix

Add an explicit `content_security_policy.extension_pages` to the Firefox manifest allowing `ws://127.0.0.1:*` (and `wss`/`https`/`http`), preventing the automatic upgrade to `wss://`. This matches the default Chrome MV3 behaviour, which already permits `ws:` to localhost.

The fix was proposed by @Oratorian in the issue thread.

## Testing

- Built and loaded the extension in Firefox (Flatpak on Fedora Toolbox)
- **Without fix:** popup stuck on "Connecting...", no connection reaches the server
- **With fix:** popup shows "Connected", handshake received by server