### PR TITLE
Fix release blockers: header rendering, disable scoping, no-tab guards

### DIFF
--- a/extensions/chrome/src/background-module.js
+++ b/extensions/chrome/src/background-module.js
@@ -434,7 +434,9 @@ registerTabCleanup(chrome, {
 // timeouts. Captured data stays scoped per tab.
 async function ensureDebuggerAttached(attachedTabId) {
   if (!attachedTabId) {
-    throw new Error('No tab attached');
+    // Callers pass the guarded snapshot, so this is an internal bug signal
+    // rather than the user-facing no-tab condition
+    throw new Error('ensureDebuggerAttached called without a tab id');
   }
 
   let session = debuggerSessions.get(attachedTabId);
@@ -663,13 +665,14 @@ async function fetchRequestData(attachedTabId, method, params, requestId) {
 
 // Handle CDP commands from MCP server
 async function handleCDPCommand(cdpMethod, cdpParams) {
-  const attachedTabId = tabHandlers.getAttachedTabId();
+  // Single read: guard and snapshot in one call, so a tab attaching
+  // between a check and a later read can't let dispatch run with null.
+  // Target.getTargets is the only command that works without a tab.
+  const attachedTabId = cdpMethod === 'Target.getTargets'
+    ? tabHandlers.getAttachedTabId()
+    : tabHandlers.requireAttachedTabId();
 
   logger.log(`[Background] handleCDPCommand called: ${cdpMethod} tab: ${attachedTabId}`);
-
-  if (!attachedTabId && cdpMethod !== 'Target.getTargets') {
-    tabHandlers.requireAttachedTabId(); // Throws the standard guidance
-  }
 
   try {
     return await dispatchCDPCommand(cdpMethod, cdpParams, attachedTabId);
@@ -1650,10 +1653,7 @@ async function dispatchCDPCommand(cdpMethod, cdpParams, attachedTabId) {
     }
 
     case 'Runtime.getDialogEvents': {
-      const attachedTabId = tabHandlers.getAttachedTabId();
-      if (!attachedTabId) {
-        throw new Error('No tab attached');
-      }
+      // attachedTabId is the guarded snapshot from dispatch
       const events = await dialogHandler.getDialogEvents(attachedTabId);
       return { events };
     }

--- a/extensions/firefox/src/background-module.js
+++ b/extensions/firefox/src/background-module.js
@@ -271,13 +271,11 @@ wsConnection.connect();
  */
 async function handleCDPCommand(params) {
   const { method, params: cdpParams } = params;
-  const attachedTabId = tabHandlers.getAttachedTabId();
+  // Single read: guard and snapshot in one call, so a tab attaching
+  // between a check and a later read can't let dispatch run with null
+  const attachedTabId = tabHandlers.requireAttachedTabId();
 
   logger.log('[Background] handleCDPCommand called:', method, 'tab:', attachedTabId);
-
-  if (!attachedTabId) {
-    tabHandlers.requireAttachedTabId(); // Throws the standard guidance
-  }
 
   switch (method) {
     case 'Page.navigate': {
@@ -455,11 +453,7 @@ async function handleCDPCommand(params) {
  */
 async function handleMouseEvent(params) {
   const { type, x, y, button = 'left', clickCount = 1 } = params;
-  const attachedTabId = tabHandlers.getAttachedTabId();
-
-  if (!attachedTabId) {
-    throw new Error('No tab attached');
-  }
+  const attachedTabId = tabHandlers.requireAttachedTabId();
 
   const buttonMap = { left: 0, middle: 1, right: 2 };
   const buttonNum = buttonMap[button] || 0;
@@ -544,11 +538,7 @@ async function handleMouseEvent(params) {
  */
 async function handleKeyEvent(params) {
   const { type, key, code, text } = params;
-  const attachedTabId = tabHandlers.getAttachedTabId();
-
-  if (!attachedTabId) {
-    throw new Error('No tab attached');
-  }
+  const attachedTabId = tabHandlers.requireAttachedTabId();
 
   // Map CDP event types to DOM event types
   const eventTypeMap = {

--- a/extensions/shared/handlers/tabs.js
+++ b/extensions/shared/handlers/tabs.js
@@ -330,10 +330,7 @@ export class TabHandlers {
       wasAttached = (tabIdToClose === this.attachedTabId);
     } else {
       // Close currently attached tab
-      if (!this.attachedTabId) {
-        throw new Error('No tab attached');
-      }
-      tabIdToClose = this.attachedTabId;
+      tabIdToClose = this.requireAttachedTabId();
       wasAttached = true;
     }
 

--- a/server/src/statefulBackend.js
+++ b/server/src/statefulBackend.js
@@ -893,16 +893,14 @@ class StatefulBackend {
       this._activeBackend = null;
     }
 
-    // Close proxy connection if we're in proxy mode. The extension stays
-    // connected to the relay after we leave, so tell it this is a
-    // deliberate disable — otherwise its debugger sessions (and the
-    // "being debugged" banners) would persist indefinitely.
+    // Close proxy connection if we're in proxy mode. Deliberately NO
+    // serverShuttingDown here: the relay multiplexes multiple MCP clients
+    // onto one extension, so the notification would force-detach every
+    // client's debugger sessions, not just this one's. Until the relay
+    // protocol carries client identity (mcp-57fb / mcp-d591), a PRO
+    // disable leaves the other clients' sessions untouched and this
+    // client's sessions to the extension's idle handling.
     if (this._proxyConnection) {
-      try {
-        this._proxyConnection.sendNotification('serverShuttingDown', {});
-      } catch (error) {
-        debugLog('[StatefulBackend] Could not notify extension of shutdown:', error.message);
-      }
       await this._proxyConnection.close();
       this._proxyConnection = null;
     }

--- a/server/src/unifiedBackend.js
+++ b/server/src/unifiedBackend.js
@@ -14,6 +14,25 @@ function debugLog(...args) {
 // One wording for the no-tab-attached state everywhere it is rendered
 const NO_TAB_ATTACHED_TEXT = `No tab attached. Use \`browser_tabs action='attach'\` to attach a tab first.`;
 
+// Headers arrive in two shapes: CDP entries carry a name->value object,
+// webRequest entries carry an array of {name, value}. Normalize to the
+// object shape before rendering so both sources display their headers.
+function normalizeHeaders(headers) {
+  if (!headers) {
+    return {};
+  }
+  if (Array.isArray(headers)) {
+    const normalized = {};
+    for (const header of headers) {
+      if (header && header.name !== undefined) {
+        normalized[header.name] = header.value ?? '';
+      }
+    }
+    return normalized;
+  }
+  return headers;
+}
+
 class UnifiedBackend {
   constructor(config, transport) {
     this._config = config;
@@ -4452,9 +4471,10 @@ class UnifiedBackend {
       let details = `### Request Details\n\n**${req.method} ${req.url}${type}**\nStatus: ${status}\nRequest ID: \`${requestId}\``;
 
       // Add request headers
-      if (req.requestHeaders && Object.keys(req.requestHeaders).length > 0) {
+      const requestHeaders = normalizeHeaders(req.requestHeaders);
+      if (Object.keys(requestHeaders).length > 0) {
         const importantHeaders = ['content-type', 'authorization', 'accept', 'user-agent', 'cookie'];
-        const headerLines = Object.entries(req.requestHeaders)
+        const headerLines = Object.entries(requestHeaders)
           .filter(([key]) => importantHeaders.includes(key.toLowerCase()))
           .map(([key, value]) => `  ${key}: ${value.length > 100 ? value.substring(0, 100) + '...' : value}`)
           .join('\n');
@@ -4512,9 +4532,10 @@ class UnifiedBackend {
       }
 
       // Add response headers
-      if (req.responseHeaders && Object.keys(req.responseHeaders).length > 0) {
+      const responseHeaders = normalizeHeaders(req.responseHeaders);
+      if (Object.keys(responseHeaders).length > 0) {
         const importantHeaders = ['content-type', 'content-length', 'cache-control', 'set-cookie'];
-        const headerLines = Object.entries(req.responseHeaders)
+        const headerLines = Object.entries(responseHeaders)
           .filter(([key]) => importantHeaders.includes(key.toLowerCase()))
           .map(([key, value]) => `  ${key}: ${value.length > 100 ? value.substring(0, 100) + '...' : value}`)
           .join('\n');


### PR DESCRIPTION
## Summary

Three fixes ahead of v1.9.22, addressing the highest-priority follow-ups from the #39 review cycle:

- **Details render headers for webRequest-tracked entries.** The renderer assumed CDP-style `name -> value` objects, but webRequest stores headers as arrays of `{name, value}` — so the header sections silently vanished for pre-attach history entries (and for all Firefox details). A normalizer now accepts both shapes for request and response headers.
- **PRO-mode `disable` no longer force-detaches other clients.** The relay multiplexes multiple MCP clients onto one extension, so broadcasting `serverShuttingDown` on one client's disable destroyed every client's debugger sessions and captures. Direct/Free mode keeps its immediate detach (single client by construction); the proper PRO release path needs client identity in the relay protocol (tracked as mcp-57fb).
- **No-tab guards are single-read.** Both CDP dispatch entries guard and snapshot the attached tab in one `requireAttachedTabId()` call, closing the window where a tab attaching mid-dispatch let a command run with a null tab id. The remaining bare `'No tab attached'` throws (Firefox mouse/key handlers, shared `closeTab`) now use the same guard, so the user-facing wording is defined in exactly one place.

## Testing

- `server`: `npm test` — 76 passed
- `extensions/chrome`: `npm run build` — lint + build pass
- Firefox and shared modules syntax-checked (not covered by CI)