### PR TITLE
Apply review follow-ups: closeTab index, header normalization, guard consistency

### DIFF
--- a/extensions/chrome/src/background-module.js
+++ b/extensions/chrome/src/background-module.js
@@ -665,14 +665,16 @@ async function fetchRequestData(attachedTabId, method, params, requestId) {
 
 // Handle CDP commands from MCP server
 async function handleCDPCommand(cdpMethod, cdpParams) {
+  // Log before the guard so a no-tab failure still records which method
+  // was attempted
+  logger.log(`[Background] handleCDPCommand called: ${cdpMethod}`);
+
   // Single read: guard and snapshot in one call, so a tab attaching
   // between a check and a later read can't let dispatch run with null.
   // Target.getTargets is the only command that works without a tab.
   const attachedTabId = cdpMethod === 'Target.getTargets'
     ? tabHandlers.getAttachedTabId()
     : tabHandlers.requireAttachedTabId();
-
-  logger.log(`[Background] handleCDPCommand called: ${cdpMethod} tab: ${attachedTabId}`);
 
   try {
     return await dispatchCDPCommand(cdpMethod, cdpParams, attachedTabId);
@@ -819,7 +821,7 @@ async function dispatchCDPCommand(cdpMethod, cdpParams, attachedTabId) {
     }
 
     case 'Input.dispatchMouseEvent':
-      return await handleMouseEvent(cdpParams);
+      return await handleMouseEvent(cdpParams, attachedTabId);
 
     case 'Input.dispatchKeyEvent': {
       // Use Chrome debugger for real trusted key events (enables form submission, etc.)
@@ -1667,8 +1669,9 @@ async function dispatchCDPCommand(cdpMethod, cdpParams, attachedTabId) {
 // Track last mousedown for click synthesis
 let lastMouseDown = null;
 
-async function handleMouseEvent(params) {
-  const attachedTabId = tabHandlers.getAttachedTabId();
+// attachedTabId is the caller's guarded snapshot, so the whole event
+// targets the same tab as the rest of the command (no re-read race)
+async function handleMouseEvent(params, attachedTabId) {
   const { type, x, y, button = 'left' } = params;
   // clickCount parameter not currently used
 
@@ -1984,8 +1987,8 @@ registerCaptureCommandHandlers(wsConnection, {
 });
 
 wsConnection.registerCommandHandler('getResponseBody', async ({ requestId }) => {
-  tabHandlers.requireAttachedTabId();
-
+  // No leading guard: handleCDPCommand guards internally, and its throw is
+  // caught below so the no-tab condition always takes the { error } shape
   try {
     // The CDP case checks availability first and attaches only when the
     // request is servable, so no eager Network.enable here
@@ -1997,8 +2000,6 @@ wsConnection.registerCommandHandler('getResponseBody', async ({ requestId }) => 
 });
 
 wsConnection.registerCommandHandler('getRequestPostData', async ({ requestId }) => {
-  tabHandlers.requireAttachedTabId();
-
   try {
     const result = await handleCDPCommand('Network.getRequestPostData', { requestId });
     return result;

--- a/extensions/firefox/src/background-module.js
+++ b/extensions/firefox/src/background-module.js
@@ -209,8 +209,8 @@ wsConnection.registerCommandHandler('selectTab', async (params) => {
   return await tabHandlers.selectTab(params);
 });
 
-wsConnection.registerCommandHandler('closeTab', async () => {
-  return await tabHandlers.closeTab();
+wsConnection.registerCommandHandler('closeTab', async (params) => {
+  return await tabHandlers.closeTab(params?.index);
 });
 
 wsConnection.registerCommandHandler('openTestPage', async () => {
@@ -271,11 +271,13 @@ wsConnection.connect();
  */
 async function handleCDPCommand(params) {
   const { method, params: cdpParams } = params;
+  // Log before the guard so a no-tab failure still records which method
+  // was attempted
+  logger.log('[Background] handleCDPCommand called:', method);
+
   // Single read: guard and snapshot in one call, so a tab attaching
   // between a check and a later read can't let dispatch run with null
   const attachedTabId = tabHandlers.requireAttachedTabId();
-
-  logger.log('[Background] handleCDPCommand called:', method, 'tab:', attachedTabId);
 
   switch (method) {
     case 'Page.navigate': {
@@ -380,10 +382,10 @@ async function handleCDPCommand(params) {
     }
 
     case 'Input.dispatchMouseEvent':
-      return await handleMouseEvent(cdpParams);
+      return await handleMouseEvent(cdpParams, attachedTabId);
 
     case 'Input.dispatchKeyEvent':
-      return await handleKeyEvent(cdpParams);
+      return await handleKeyEvent(cdpParams, attachedTabId);
 
     case 'Page.captureScreenshot': {
       try {
@@ -451,9 +453,9 @@ async function handleCDPCommand(params) {
 /**
  * Handle mouse events via JavaScript injection
  */
-async function handleMouseEvent(params) {
+// attachedTabId is the caller's guarded snapshot (no re-read race)
+async function handleMouseEvent(params, attachedTabId) {
   const { type, x, y, button = 'left', clickCount = 1 } = params;
-  const attachedTabId = tabHandlers.requireAttachedTabId();
 
   const buttonMap = { left: 0, middle: 1, right: 2 };
   const buttonNum = buttonMap[button] || 0;
@@ -536,9 +538,9 @@ async function handleMouseEvent(params) {
 /**
  * Handle keyboard events via JavaScript injection
  */
-async function handleKeyEvent(params) {
+// attachedTabId is the caller's guarded snapshot (no re-read race)
+async function handleKeyEvent(params, attachedTabId) {
   const { type, key, code, text } = params;
-  const attachedTabId = tabHandlers.requireAttachedTabId();
 
   // Map CDP event types to DOM event types
   const eventTypeMap = {

--- a/server/src/statefulBackend.js
+++ b/server/src/statefulBackend.js
@@ -894,12 +894,14 @@ class StatefulBackend {
     }
 
     // Close proxy connection if we're in proxy mode. Deliberately NO
-    // serverShuttingDown here: the relay multiplexes multiple MCP clients
-    // onto one extension, so the notification would force-detach every
-    // client's debugger sessions, not just this one's. Until the relay
-    // protocol carries client identity (mcp-57fb / mcp-d591), a PRO
-    // disable leaves the other clients' sessions untouched and this
-    // client's sessions to the extension's idle handling.
+    // serverShuttingDown here (MCPConnection.sendNotification is the
+    // intentionally-unused hook for it): the relay multiplexes multiple
+    // MCP clients onto one extension, so the notification would
+    // force-detach every client's debugger sessions, not just this one's.
+    // Known cost: this client's sessions and debug banners persist until
+    // the extension's relay connection drops or the browser restarts —
+    // there is currently no per-client release path. Fixing that needs
+    // client identity in the relay protocol (mcp-57fb / mcp-d591).
     if (this._proxyConnection) {
       await this._proxyConnection.close();
       this._proxyConnection = null;

--- a/server/src/unifiedBackend.js
+++ b/server/src/unifiedBackend.js
@@ -15,8 +15,11 @@ function debugLog(...args) {
 const NO_TAB_ATTACHED_TEXT = `No tab attached. Use \`browser_tabs action='attach'\` to attach a tab first.`;
 
 // Headers arrive in two shapes: CDP entries carry a name->value object,
-// webRequest entries carry an array of {name, value}. Normalize to the
-// object shape before rendering so both sources display their headers.
+// webRequest entries carry an array of {name, value} (or binaryValue for
+// non-UTF-8 bytes). Normalize to the object shape so every consumer —
+// rendered text, rawResult, replay — sees one format. Repeated headers
+// (multiple Set-Cookie) are joined per RFC 9110 list syntax rather than
+// collapsed last-wins.
 function normalizeHeaders(headers) {
   if (!headers) {
     return {};
@@ -24,9 +27,13 @@ function normalizeHeaders(headers) {
   if (Array.isArray(headers)) {
     const normalized = {};
     for (const header of headers) {
-      if (header && header.name !== undefined) {
-        normalized[header.name] = header.value ?? '';
+      if (!header || header.name === undefined) {
+        continue;
       }
+      const value = header.value ?? (header.binaryValue ? '<binary value>' : '');
+      normalized[header.name] = header.name in normalized
+        ? `${normalized[header.name]}, ${value}`
+        : value;
     }
     return normalized;
   }
@@ -4330,6 +4337,18 @@ class UnifiedBackend {
     }
 
     const requests = result.requests || [];
+
+    // Normalize header shapes once, so the rendered text, rawResult and
+    // replay consumers all see the same object format regardless of
+    // whether an entry came from the CDP or webRequest tracker
+    for (const req of requests) {
+      if (req.requestHeaders) {
+        req.requestHeaders = normalizeHeaders(req.requestHeaders);
+      }
+      if (req.responseHeaders) {
+        req.responseHeaders = normalizeHeaders(req.responseHeaders);
+      }
+    }
 
     if (requests.length === 0) {
       if (options.rawResult) {


### PR DESCRIPTION
## Summary

Follow-ups from the review of #50, all small and surgical:

- **Firefox `closeTab` forwards the index parameter.** The handler registered with no params, so `browser_tabs action='close' index=N` closed the currently attached tab instead of tab N (or threw when unattached) while reporting `closedIndex: N`.
- **Header normalization hardened and centralized.** Repeated headers (multiple `Set-Cookie`) join per RFC 9110 list syntax instead of collapsing last-wins; `binaryValue`-only headers render `<binary value>` instead of an empty string; and normalization runs once when the request list is fetched, so rendered text, rawResult/script mode, and replay all see the same object shape.
- **Guarded snapshot reaches the leaf handlers.** Mouse/key event handlers in both browsers now take the dispatch guard's tab snapshot as a parameter instead of re-reading attachment state mid-command — closing the same double-read race at the leaves that #50 closed at dispatch.
- **One wire shape for the no-tab condition** on body fetches: the redundant leading guards in `getResponseBody`/`getRequestPostData` are gone, so the condition consistently takes the `{ error }` shape through the existing catch.
- **Honest PRO-disable comment**: states the real consequence (sessions persist until the relay connection drops; no per-client release path yet — mcp-57fb) instead of citing idle handling that doesn't exist.
- **CDP dispatch logs the method before the guard**, so failed commands still leave a trace in the extension console.

One pre-existing finding from the same review is deliberately not addressed here: list/close and attach/create resolve tab indexes through different orderings across multiple windows — tracked separately as mcp-c57c.

## Testing

- `server`: `npm test` — 76 passed
- `extensions/chrome`: `npm run build` — lint + build pass
- Firefox and shared modules syntax-checked (not covered by CI)