### PR TITLE
Fix off-screen clicks, tab index consistency, and startup hardening

### DIFF
--- a/extensions/chrome/src/background-module.js
+++ b/extensions/chrome/src/background-module.js
@@ -18,38 +18,49 @@ import { ConsoleHandler } from '../../shared/handlers/console.js';
 import { createBrowserAdapter } from '../../shared/adapters/browser.js';
 import { wrapWithUnwrap, shouldUnwrap } from '../../shared/utils/unwrap.js';
 import { setupInstallHandler } from '../../shared/handlers/install.js';
+import { safeInit, reportFatalInit } from '../../shared/utils/safeInit.js';
 
 // Initialize browser adapter at top level (before async IIFE)
 const browserAdapter = createBrowserAdapter();
 const chrome = browserAdapter.getRawAPI();
 
-// Set up welcome page to open on first install (must be at top level for MV3)
-// Browser name is auto-detected from manifest.json
-setupInstallHandler(chrome);
+const PRODUCT_NAME = 'Blueprint MCP for Chrome';
+
+// Top-level init steps are individually guarded: a throw here would kill
+// the service worker before the connection code ever runs, leaving the
+// extension permanently "Connecting…" with no product-prefixed error
+// (the failure mode reported for Firefox in issue #49)
+safeInit(PRODUCT_NAME, 'install handler', () => {
+  // Set up welcome page to open on first install (must be at top level for MV3)
+  // Browser name is auto-detected from manifest.json
+  setupInstallHandler(chrome);
+});
 
 // Top-level variables for tab monitoring
 let tabHandlers = null;
 let wsConnection = null;
 
-// Write to storage immediately to confirm script is loading
-chrome.storage.local.set({
-  backgroundScriptLoaded: {
-    timestamp: new Date().toISOString(),
-    message: 'Background script loaded successfully!'
-  }
+safeInit(PRODUCT_NAME, 'startup storage markers', () => {
+  // Write to storage immediately to confirm script is loading
+  chrome.storage.local.set({
+    backgroundScriptLoaded: {
+      timestamp: new Date().toISOString(),
+      message: 'Background script loaded successfully!'
+    }
+  });
+
+  // Also write to storage to confirm listener is being registered
+  chrome.storage.local.set({
+    listenerRegistered: {
+      timestamp: new Date().toISOString(),
+      message: 'tabs.onUpdated listener registered!'
+    }
+  });
 });
 
 // Register tabs.onUpdated listener at TOP LEVEL (not inside async function)
 // This ensures it persists through service worker suspensions in MV3
 console.error('[Background] ⚡ Registering tabs.onUpdated listener at TOP LEVEL...');
-
-// Also write to storage to confirm listener is being registered
-chrome.storage.local.set({
-  listenerRegistered: {
-    timestamp: new Date().toISOString(),
-    message: 'tabs.onUpdated listener registered!'
-  }
-});
 
 chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
   // Check if tabHandlers is initialized yet
@@ -115,15 +126,17 @@ chrome.tabs.onUpdated.addListener(async (tabId, changeInfo, tab) => {
 console.error('[Background] ✅ tabs.onUpdated listener registered at TOP LEVEL!');
 
 // Main initialization
-(async () => {
+// The catch below is the line to look for when the extension never connects
+reportFatalInit((async () => {
 
 // Note: Use browserAdapter.executeScript instead of defining a local executeScript
 // The browserAdapter version properly handles both 'func' and 'code' parameters
 // and avoids CSP issues by not using eval() when possible
 
-// Initialize logger
-const logger = new Logger('Blueprint MCP for Chrome');
-await logger.init(chrome);
+// Initialize logger. A storage failure must not stop the connection from
+// being attempted — the logger object works unconfigured.
+const logger = new Logger(PRODUCT_NAME);
+await safeInit(PRODUCT_NAME, 'logger', () => logger.init(chrome));
 const manifest = chrome.runtime.getManifest();
 logger.logAlways(`Blueprint MCP v${manifest.version}`);
 
@@ -159,10 +172,10 @@ tabHandlers.setDialogInjector((tabId) => dialogHandler.setupDialogOverrides(tabI
 consoleHandler.setupMessageListener();
 
 // Initialize icon manager
-iconManager.init();
+safeInit(PRODUCT_NAME, 'icon manager', () => iconManager.init(), logger);
 
 // Initialize network tracker
-networkTracker.init();
+safeInit(PRODUCT_NAME, 'network tracker', () => networkTracker.init(), logger);
 
 // State variables
 let techStackInfo = {}; // Stores detected tech stack per tab
@@ -536,9 +549,10 @@ async function enableCaptureDomains(tabId, session) {
 // shrinks again as sessions go idle.
 // Accepted tradeoff: a single command running longer than the idle window
 // on a tab that is no longer the attached target can have its session
-// evicted mid-command (the command fails with "Detached while handling
-// command" and retries cleanly). Tracking per-command pins proved more
-// error-prone than this window (see history in the PR).
+// evicted mid-command — the command fails with "Detached while handling
+// command" and the error surfaces to the caller (nothing retries it
+// automatically; the next command re-attaches lazily). Tracking
+// per-command pins proved more error-prone than this window.
 let evictionRetryTimer = null;
 
 function evictLeastRecentlyUsedSessions(protectedTabId) {
@@ -697,15 +711,13 @@ async function dispatchCDPCommand(cdpMethod, cdpParams, attachedTabId) {
     case 'Target.getTargets':
       return await tabHandlers.getTabs();
 
-    case 'Target.attachToTarget': {
-      const tabId = cdpParams.targetId;
-      return await tabHandlers.selectTab(parseInt(tabId));
-    }
+    // These handlers take params objects; passing bare values silently
+    // selected nothing / opened about:blank
+    case 'Target.attachToTarget':
+      return await tabHandlers.selectTab({ tabIndex: parseInt(cdpParams.targetId, 10) });
 
-    case 'Target.createTarget': {
-      const url = cdpParams.url || 'about:blank';
-      return await tabHandlers.createTab(url);
-    }
+    case 'Target.createTarget':
+      return await tabHandlers.createTab({ url: cdpParams.url || 'about:blank' });
 
     case 'Target.closeTarget': {
       const tabId = cdpParams.targetId;
@@ -1910,11 +1922,19 @@ wsConnection.registerCommandHandler('openTestPage', async () => {
     height: 900
   });
 
+  const tabId = window.tabs[0].id;
+
+  // Attach to the new tab. The server reports this page as attached, so
+  // the extension must agree — otherwise every following command runs
+  // against the previously attached tab while the status header claims
+  // the test page.
+  await tabHandlers.attachToTabId(tabId);
+
   return {
     success: true,
     url: testPageUrl,
     windowId: window.id,
-    tabId: window.tabs[0].id
+    tabId
   };
 });
 
@@ -2073,4 +2093,4 @@ if (isEnabled) {
 }
 
 // End of main initialization
-})();
+})(), PRODUCT_NAME);

--- a/extensions/firefox/src/background-module.js
+++ b/extensions/firefox/src/background-module.js
@@ -18,28 +18,39 @@ import { ConsoleHandler } from '../shared/handlers/console.js';
 import { createBrowserAdapter } from '../shared/adapters/browser.js';
 import { wrapWithUnwrap, shouldUnwrap } from '../shared/utils/unwrap.js';
 import { setupInstallHandler } from '../shared/handlers/install.js';
+import { safeInit, reportFatalInit } from '../shared/utils/safeInit.js';
 
 // Initialize browser adapter at top level (before async IIFE) for install handler
 const browserAdapter = createBrowserAdapter();
 const browser = browserAdapter.getRawAPI();
 
-// Set up welcome page to open on first install (must be at top level)
-// Browser name is auto-detected from manifest.json
-setupInstallHandler(browser);
+const PRODUCT_NAME = 'Blueprint MCP for Firefox';
 
-// Set up keepalive alarm at TOP LEVEL (prevents service worker suspension in MV3)
-// This must be synchronous to ensure the listener is registered before service worker sleeps
-if (browser.alarms) {
-  browser.alarms.create('keepalive', { periodInMinutes: 1 });
-  browser.alarms.onAlarm.addListener((alarm) => {
-    if (alarm.name === 'keepalive') {
-      console.log('[Background] Keepalive alarm - service worker active');
-    }
-  });
-}
+// Top-level init steps are individually guarded: a throw here would kill
+// the whole module before the connection code ever runs (see issue #49,
+// where the background died on startup with no add-on-prefixed error)
+safeInit(PRODUCT_NAME, 'install handler', () => {
+  // Set up welcome page to open on first install (must be at top level)
+  // Browser name is auto-detected from manifest.json
+  setupInstallHandler(browser);
+});
 
-// Main initialization
-(async () => {
+safeInit(PRODUCT_NAME, 'keepalive alarm', () => {
+  // Set up keepalive alarm at TOP LEVEL (prevents service worker suspension in MV3)
+  // This must be synchronous to ensure the listener is registered before service worker sleeps
+  if (browser.alarms) {
+    browser.alarms.create('keepalive', { periodInMinutes: 1 });
+    browser.alarms.onAlarm.addListener((alarm) => {
+      if (alarm.name === 'keepalive') {
+        console.log('[Background] Keepalive alarm - service worker active');
+      }
+    });
+  }
+});
+
+// Main initialization. The catch is the line to look for when the
+// extension never connects (issue #49)
+reportFatalInit((async () => {
 
 /**
  * Execute script helper - Manifest V3 compatible
@@ -70,10 +81,14 @@ async function executeScript(tabId, options) {
   throw new Error('No executeScript API available - scripting permission may be missing');
 }
 
-// Initialize logger
-const logger = new Logger('Blueprint MCP for Firefox');
-await logger.init(browser);
+// Initialize logger. A storage failure must not stop the connection from
+// being attempted — the logger object works unconfigured.
+const logger = new Logger(PRODUCT_NAME);
+await safeInit(PRODUCT_NAME, 'logger', () => logger.init(browser));
 logger.logAlways('[Background] Extension loaded (modular version)');
+
+// Local alias so every pre-connect step reads the same way
+const step = (name, fn) => safeInit(PRODUCT_NAME, name, fn, logger);
 
 // Read build timestamp (read once at startup)
 let buildTimestamp = null;
@@ -95,17 +110,17 @@ const dialogHandler = new DialogHandler(browserAdapter, logger);
 const consoleHandler = new ConsoleHandler(browserAdapter, logger);
 
 // Initialize icon manager
-iconManager.init();
+step('icon manager', () => iconManager.init());
 
 // Initialize network tracker
-networkTracker.init();
+step('network tracker', () => networkTracker.init());
 
 // State variables
 let techStackInfo = {}; // Stores detected tech stack per tab
 let pendingDialogResponse = null; // Stores response for next dialog
 
 // Set up console message listener from content script
-browser.runtime.onMessage.addListener(async (message, sender) => {
+const onRuntimeMessage = async (message, sender) => {
   if (message.type === 'console' && sender.tab) {
     consoleHandler.addMessage({
       tabId: sender.tab.id,
@@ -167,14 +182,17 @@ browser.runtime.onMessage.addListener(async (message, sender) => {
     await browser.tabs.update(sender.tab.id, { active: true });
     await browser.windows.update(sender.tab.windowId, { focused: true });
   }
-});
+};
+step('runtime message listener', () => browser.runtime.onMessage.addListener(onRuntimeMessage));
 
 // Set up console and dialog injectors for tab handlers
-tabHandlers.setConsoleInjector((tabId) => consoleHandler.injectConsoleCapture(tabId));
-tabHandlers.setDialogInjector((tabId) => dialogHandler.setupDialogOverrides(tabId));
+step('injectors', () => {
+  tabHandlers.setConsoleInjector((tabId) => consoleHandler.injectConsoleCapture(tabId));
+  tabHandlers.setDialogInjector((tabId) => dialogHandler.setupDialogOverrides(tabId));
+});
 
 // Listen for tab navigation to re-inject dialog overrides
-browser.webNavigation.onCompleted.addListener(async (details) => {
+const onNavigationCompleted = async (details) => {
   const attachedTabId = tabHandlers.getAttachedTabId();
 
   if (details.tabId === attachedTabId && details.frameId === 0) {
@@ -182,16 +200,17 @@ browser.webNavigation.onCompleted.addListener(async (details) => {
     await consoleHandler.injectConsoleCapture(details.tabId);
     await dialogHandler.setupDialogOverrides(details.tabId);
   }
-});
+};
+step('navigation listener', () => browser.webNavigation.onCompleted.addListener(onNavigationCompleted));
 
 // Tab-close cleanup is shared across browsers
-registerTabCleanup(browser, {
+step('tab cleanup', () => registerTabCleanup(browser, {
   tabHandlers,
   networkTracker,
   consoleHandler,
   techStackInfo,
   logger
-});
+}));
 
 // Initialize WebSocket connection
 const wsConnection = new WebSocketConnection(browser, logger, iconManager, buildTimestamp);
@@ -233,12 +252,12 @@ wsConnection.registerCommandHandler('openTestPage', async () => {
 
 // Network/console read+clear handlers are shared across browsers (Firefox
 // has no CDP capture, so the webRequest tracker is the only source)
-registerCaptureCommandHandlers(wsConnection, {
+step('capture commands', () => registerCaptureCommandHandlers(wsConnection, {
   tabHandlers,
   networkTracker,
   consoleHandler,
   logger
-});
+}));
 
 wsConnection.registerCommandHandler('forwardCDPCommand', async (params) => {
   return await handleCDPCommand(params);
@@ -665,8 +684,9 @@ async function handleOpenTestPage() {
     active: true
   });
 
-  // Wait for page to load
-  await new Promise(resolve => setTimeout(resolve, 1000));
+  // Attach to the new tab so the extension agrees with the server's
+  // reported attachment (otherwise later commands hit the previous tab)
+  await tabHandlers.attachToTabId(tab.id);
 
   return {
     tab: { id: tab.id, url: tab.url },
@@ -721,6 +741,4 @@ function buildTechStackMessage(detectedStack) {
 
 logger.logAlways('[Background] Background script initialized with modular architecture');
 
-})().catch(error => {
-  console.error('[Background] Initialization failed:', error);
-});
+})(), PRODUCT_NAME);

--- a/extensions/shared/connection/websocket.js
+++ b/extensions/shared/connection/websocket.js
@@ -48,8 +48,26 @@ export class WebSocketConnection {
   }
 
   _markSessionEstablished() {
+    if (this._sessionEstablished) {
+      return;
+    }
     this._sessionEstablished = true;
+    // Kept so a connection refused before any real traffic can roll the
+    // timestamp back (see _markSessionRejected)
+    this._connectedAtBeforeSession = this.lastConnectedAt;
+    this._sessionUsed = false;
     this.lastConnectedAt = Date.now();
+  }
+
+  _markSessionUsed() {
+    this._sessionUsed = true;
+  }
+
+  _markSessionRejected() {
+    if (this._sessionEstablished && !this._sessionUsed) {
+      this.lastConnectedAt = this._connectedAtBeforeSession;
+      this._sessionEstablished = false;
+    }
   }
 
   // Unbind all handlers and drop the socket. Handlers must be unbound
@@ -369,7 +387,14 @@ export class WebSocketConnection {
   _handleOpen() {
     this.logger.logAlways(`Connected to ${this.connectionUrl}`);
     this.isConnected = true;
-    this._markSessionEstablished();
+    // Free mode: the local server accepting the socket IS the session —
+    // it sends no unsolicited frame to wait for. A refusal (duplicate
+    // extension) arrives as an error frame and rolls this back.
+    // PRO mode: wait for authentication to actually succeed, so an
+    // expired-token reject loop can't keep refreshing lastConnectedAt.
+    if (!this.isPro) {
+      this._markSessionEstablished();
+    }
 
     // Update icon manager
     if (this.iconManager) {
@@ -422,8 +447,16 @@ export class WebSocketConnection {
       // Handle error responses from server
       if (message.error) {
         this.logger.logAlways('[WebSocket] Server error response:', message.error);
+        // A server error before any real traffic means this connection was
+        // refused (duplicate extension, failed auth). Undo the timestamp
+        // so a rejection loop can't masquerade as a healthy connection
+        // and starve consumers measuring downtime.
+        this._markSessionRejected();
         return;
       }
+
+      // Real inbound traffic confirms a working session
+      this._markSessionUsed();
 
       // Handle notifications (no id, has method)
       if (!message.id && message.method) {
@@ -604,6 +637,11 @@ export class WebSocketConnection {
       client_id: clientId,
       buildTimestamp: this.buildTimestamp
     };
+
+    // Authentication succeeded (every failure path above throws), so the
+    // PRO session is now genuinely established
+    this._markSessionEstablished();
+    this._markSessionUsed();
 
     this.logger.log('[WebSocket] Responding to authenticate request');
     return authResponse;

--- a/extensions/shared/handlers/tabs.js
+++ b/extensions/shared/handlers/tabs.js
@@ -92,32 +92,64 @@ export class TabHandlers {
    * Handle getTabs command
    * Returns list of all tabs from all windows
    */
-  async getTabs() {
-    // Get all tabs from all windows
+  /**
+   * All tabs in the one canonical user-facing order: windows.getAll
+   * flattening. Every index shown to or accepted from the user MUST
+   * resolve through this list — tabs.query({}) orders (and filters
+   * window types) differently, so mixing the two could map a listed
+   * index onto a different tab when attaching or closing.
+   */
+  async getOrderedTabs() {
     const windows = await this.browser.windows.getAll({ populate: true });
-    const tabs = [];
-    let tabIndex = 0;
+    return windows.flatMap(window => window.tabs || []);
+  }
 
-    windows.forEach(window => {
-      window.tabs.forEach(tab => {
-        // Check if tab is automatable (not about:, moz-extension:, chrome:, etc.)
-        const isAutomatable = tab.url &&
-          !['about:', 'moz-extension:', 'chrome:', 'chrome-extension:'].some(scheme =>
-            tab.url.startsWith(scheme)
-          );
+  /**
+   * Attach to a tab by id, waiting for its URL to materialize. A tab
+   * created moments ago reports no URL yet, which the automatable check
+   * would reject — so callers that just opened a page poll briefly here
+   * instead of racing it.
+   * @param {number} tabId - Tab to attach to
+   * @param {object} options - { activate, timeoutMs }
+   */
+  async attachToTabId(tabId, { activate = true, timeoutMs = 5000 } = {}) {
+    const deadline = Date.now() + timeoutMs;
 
-        tabs.push({
-          id: tab.id,
-          windowId: window.id,
-          title: tab.title,
-          url: tab.url,
-          active: tab.active,
-          index: tabIndex,
-          automatable: isAutomatable
-        });
+    while (Date.now() < deadline) {
+      const tab = await this.browser.tabs.get(tabId).catch(() => null);
+      if (tab && tab.url && tab.url !== 'about:blank') {
+        break;
+      }
+      await new Promise(resolve => setTimeout(resolve, 150));
+    }
 
-        tabIndex++;
-      });
+    const orderedTabs = await this.getOrderedTabs();
+    const tabIndex = orderedTabs.findIndex(t => t.id === tabId);
+    if (tabIndex < 0) {
+      throw new Error(`Tab ${tabId} not found after opening`);
+    }
+    return this.selectTab({ tabIndex, activate });
+  }
+
+  async getTabs() {
+    const orderedTabs = await this.getOrderedTabs();
+
+    const tabs = orderedTabs.map((tab, tabIndex) => {
+      // Check if tab is automatable (not about:, moz-extension:, chrome:, etc.)
+      const isAutomatable = tab.url &&
+        !['about:', 'moz-extension:', 'chrome:', 'chrome-extension:'].some(scheme =>
+          tab.url.startsWith(scheme)
+        );
+
+      return {
+        id: tab.id,
+        windowId: tab.windowId,
+        title: tab.title,
+        url: tab.url,
+        active: tab.active,
+        index: tabIndex,
+        automatable: isAutomatable
+      };
     });
 
     return { tabs };
@@ -148,8 +180,9 @@ export class TabHandlers {
       this.logger.log(`[TabHandlers] Stored stealth=${stealth} for tab ${tab.id}`);
     }
 
-    // Get all tabs to find the index of the newly created tab
-    const allTabs = await this.browser.tabs.query({});
+    // Get all tabs to find the index of the newly created tab (canonical
+    // ordering, matching what getTabs reports)
+    const allTabs = await this.getOrderedTabs();
     const tabIndex = allTabs.findIndex(t => t.id === tab.id);
 
     // Clear badge from old tab if there was one
@@ -220,10 +253,13 @@ export class TabHandlers {
     const activate = params.activate ?? false; // Default to false - don't steal focus
     const stealth = params.stealth ?? false;
 
-    // Get all tabs
-    const allTabs = await this.browser.tabs.query({});
+    // Get all tabs in the canonical ordering, so the index the user saw
+    // in the listing resolves to the same tab here
+    const allTabs = await this.getOrderedTabs();
 
-    if (tabIndex < 0 || tabIndex >= allTabs.length) {
+    // Integer check included: a missing or fractional index would slip
+    // past a bare range test and fail later with an opaque TypeError
+    if (!Number.isInteger(tabIndex) || tabIndex < 0 || tabIndex >= allTabs.length) {
       throw new Error(`Tab index ${tabIndex} out of range (0-${allTabs.length - 1})`);
     }
 
@@ -310,16 +346,10 @@ export class TabHandlers {
     let wasAttached = false;
 
     if (index !== undefined) {
-      // Close tab by index - use same method as getTabs() to ensure consistent ordering
-      const windows = await this.browser.windows.getAll({ populate: true });
-      const allTabs = [];
-      windows.forEach(window => {
-        window.tabs.forEach(tab => {
-          allTabs.push(tab);
-        });
-      });
+      // Close tab by index, resolved through the canonical ordering
+      const allTabs = await this.getOrderedTabs();
 
-      if (index < 0 || index >= allTabs.length) {
+      if (!Number.isInteger(index) || index < 0 || index >= allTabs.length) {
         throw new Error(`Tab index ${index} out of range (0-${allTabs.length - 1})`);
       }
 

--- a/extensions/shared/utils/safeInit.js
+++ b/extensions/shared/utils/safeInit.js
@@ -1,0 +1,60 @@
+/**
+ * Startup guards shared by the browser background scripts.
+ *
+ * Background scripts run a chain of init steps before opening the server
+ * connection. A throw in any of them kills the whole script, so the
+ * extension never connects and the popup hangs at "Connecting…" with no
+ * add-on-prefixed error (see issue #49). These helpers keep optional init
+ * failures from reaching the connection code, and make the fatal case
+ * loud when something truly unrecoverable happens.
+ */
+
+/**
+ * Run one non-essential init step, logging (never rethrowing) failures.
+ * Accepts sync or async steps; returns a promise when the step is async.
+ *
+ * @param {string} productName - Log prefix, e.g. "Blueprint MCP for Chrome"
+ * @param {string} stepName - Human-readable step name for the log line
+ * @param {function} fn - The init step
+ * @param {object} [logger] - Optional logger; falls back to console
+ */
+export function safeInit(productName, stepName, fn, logger = null) {
+  const report = (error) => {
+    const message = `[${productName}] Init step failed (continuing): ${stepName}:`;
+    if (logger && logger.logAlways) {
+      logger.logAlways(message, error);
+    } else {
+      console.error(message, error);
+    }
+  };
+
+  try {
+    const result = fn();
+    if (result && typeof result.catch === 'function') {
+      return result.catch((error) => {
+        report(error);
+      });
+    }
+    return result;
+  } catch (error) {
+    report(error);
+    return undefined;
+  }
+}
+
+/**
+ * Attach a loud, product-prefixed handler to the background script's main
+ * initialization promise. This is the line to look for when the extension
+ * never connects.
+ *
+ * @param {Promise} initPromise - The main init IIFE's promise
+ * @param {string} productName - Log prefix
+ */
+export function reportFatalInit(initPromise, productName) {
+  return initPromise.catch((error) => {
+    console.error(
+      `[${productName}] FATAL: background initialization failed, extension will not connect:`,
+      error
+    );
+  });
+}

--- a/server/src/unifiedBackend.js
+++ b/server/src/unifiedBackend.js
@@ -242,7 +242,7 @@ class UnifiedBackend {
                     description: 'Type of interaction'
                   },
                   selector: { type: 'string', description: 'CSS selector (for click, type, clear, hover, scroll_to, scroll_by, scroll_into_view, select_option, file_upload, force_pseudo_state). For scroll_to/scroll_by: scrolls the element instead of the window' },
-                  text: { type: 'string', description: 'Text to type (for type action)' },
+                  text: { type: 'string', description: 'Text to type (for type action). Typed as real key events, so a newline behaves like pressing Enter: it inserts a line break in a textarea but submits a single-line form field.' },
                   key: { type: 'string', description: 'Key to press (for press_key action)' },
                   value: { type: 'string', description: 'Option value or text to select (for select_option action). Matches by value first, then by text if value not found. Case-insensitive for text matching.' },
                   pseudoStates: {
@@ -1288,6 +1288,7 @@ class UnifiedBackend {
                   }
 
                   matches.push({
+                    index: matches.length,
                     x: rect.left + rect.width / 2,
                     y: rect.top + rect.height / 2,
                     visible: visible,
@@ -1337,6 +1338,7 @@ class UnifiedBackend {
               }
 
               matches.push({
+                index: matches.length,
                 x: rect.left + rect.width / 2,
                 y: rect.top + rect.height / 2,
                 visible: visible,
@@ -1358,7 +1360,84 @@ class UnifiedBackend {
    * Handles both regular CSS selectors and :has-text() pseudo-selectors
    * Returns: { x, y, warning } or null
    */
-  async _findElement(selectorOrObj) {
+  /**
+   * Build the page-side expression that re-selects the matched elements,
+   * mirroring _findAllElements' two query forms.
+   */
+  _buildMatchQueryExpression(selectorOrObj) {
+    if (typeof selectorOrObj === 'object' && selectorOrObj.type === 'has-text') {
+      return `
+        (() => {
+          const baseSelector = ${JSON.stringify(selectorOrObj.baseSelector)};
+          const searchText = ${JSON.stringify(selectorOrObj.searchText)};
+          const remainderSelector = ${JSON.stringify(selectorOrObj.remainderSelector)};
+          const out = [];
+          for (const el of document.querySelectorAll(baseSelector)) {
+            const text = (el.textContent || el.innerText || '').trim();
+            if (!text.toLowerCase().includes(searchText.trim().toLowerCase())) continue;
+            let targetEl = el;
+            if (remainderSelector) {
+              const descendant = el.querySelector(remainderSelector);
+              if (!descendant) continue;
+              targetEl = descendant;
+            }
+            out.push(targetEl);
+          }
+          return out;
+        })()
+      `;
+    }
+    return `Array.from(document.querySelectorAll(${JSON.stringify(selectorOrObj)}))`;
+  }
+
+  /**
+   * Scroll the matched element into view and return fresh viewport
+   * coordinates. Mouse events are dispatched in viewport space, so an
+   * element below the fold must be scrolled into view first — otherwise
+   * the click is delivered at a point outside the window and silently
+   * hits nothing. Uses instant scrolling: smooth scrolling is animated
+   * and would leave the coordinates stale.
+   */
+  async _scrollIntoViewAndMeasure(selectorOrObj, index) {
+    const result = await this._transport.sendCommand('forwardCDPCommand', {
+      method: 'Runtime.evaluate',
+      params: {
+        expression: `
+          (() => {
+            const els = ${this._buildMatchQueryExpression(selectorOrObj)};
+            const el = els[${index}];
+            if (!el) return null;
+
+            const before = el.getBoundingClientRect();
+            const outOfView = before.top < 0 || before.left < 0 ||
+              before.bottom > window.innerHeight || before.right > window.innerWidth;
+            if (outOfView) {
+              el.scrollIntoView({ block: 'center', inline: 'center', behavior: 'instant' });
+            }
+
+            const rect = el.getBoundingClientRect();
+            return {
+              x: rect.left + rect.width / 2,
+              y: rect.top + rect.height / 2,
+              scrolled: outOfView,
+              inViewport: rect.top >= 0 && rect.left >= 0 &&
+                rect.bottom <= window.innerHeight && rect.right <= window.innerWidth
+            };
+          })()
+        `,
+        returnByValue: true
+      }
+    });
+
+    return result.result?.value || null;
+  }
+
+  /**
+   * @param {object} options - { ensureInViewport } scrolls the selected
+   *   element into view and re-measures before returning coordinates.
+   *   Callers that dispatch mouse events must pass it.
+   */
+  async _findElement(selectorOrObj, options = {}) {
     const matches = await this._findAllElements(selectorOrObj);
 
     if (matches.length === 0) {
@@ -1388,6 +1467,18 @@ class UnifiedBackend {
 
     // Use first visible element, or first element if all hidden
     const selectedMatch = visibleMatches.length > 0 ? visibleMatches[0] : matches[0];
+
+    if (options.ensureInViewport && selectedMatch.index !== undefined) {
+      const measured = await this._scrollIntoViewAndMeasure(selectorOrObj, selectedMatch.index);
+      if (measured) {
+        if (!measured.inViewport) {
+          warning = warning
+            ? `${warning}. Element could not be brought fully into view`
+            : 'Element could not be brought fully into view';
+        }
+        return { x: measured.x, y: measured.y, warning };
+      }
+    }
 
     return {
       x: selectedMatch.x,
@@ -1697,8 +1788,9 @@ class UnifiedBackend {
             }
 
             // Not a select - proceed with normal click
-            // Get element location
-            const elemResult = await this._findElement(processedSelector);
+            // Get element location, scrolling it into view first so the
+            // mouse event lands inside the viewport
+            const elemResult = await this._findElement(processedSelector, { ensureInViewport: true });
 
             if (!elemResult) {
               // Try to find alternative selectors
@@ -1905,16 +1997,9 @@ class UnifiedBackend {
               }
             });
 
-            // Type each character
-            for (const char of action.text) {
-              await this._transport.sendCommand('forwardCDPCommand', {
-                method: 'Input.dispatchKeyEvent',
-                params: {
-                  type: 'char',
-                  text: char
-                }
-              });
-            }
+            // Type as full keyDown/keyUp sequences (see _typeText):
+            // required by canvas-based editors like Google Sheets
+            await this._typeText(action.text);
 
             // Get the final value of the field after typing
             const valueResult = await this._transport.sendCommand('forwardCDPCommand', {
@@ -1963,53 +2048,8 @@ class UnifiedBackend {
           }
 
           case 'press_key': {
-            const key = action.key;
-
-            // Map common keys to their key codes
-            const keyCodeMap = {
-              'Enter': 13,
-              'Escape': 27,
-              'Tab': 9,
-              'Backspace': 8,
-              'Delete': 46,
-              'ArrowUp': 38,
-              'ArrowDown': 40,
-              'ArrowLeft': 37,
-              'ArrowRight': 39,
-              'Space': 32
-            };
-
-            const code = keyCodeMap[key];
-            const text = key === 'Enter' ? '\r' : (key === 'Tab' ? '\t' : (key.length === 1 ? key : ''));
-
-            const baseParams = {
-              key: key,
-              code: key,
-              windowsVirtualKeyCode: code,
-              nativeVirtualKeyCode: code,
-              text: text,
-              unmodifiedText: text
-            };
-
-            // Send keyDown
-            await this._transport.sendCommand('forwardCDPCommand', {
-              method: 'Input.dispatchKeyEvent',
-              params: {
-                type: 'keyDown',
-                ...baseParams
-              }
-            });
-
-            // Send keyUp
-            await this._transport.sendCommand('forwardCDPCommand', {
-              method: 'Input.dispatchKeyEvent',
-              params: {
-                type: 'keyUp',
-                ...baseParams
-              }
-            });
-
-            result = `Pressed key: ${key}`;
+            await this._pressKey(action.key);
+            result = `Pressed key: ${action.key}`;
             break;
           }
 
@@ -2017,8 +2057,9 @@ class UnifiedBackend {
             // Process selector (preprocess + validate)
             const processedSelector = this._processSelector(action.selector);
 
-            // Get element location
-            const elemResult = await this._findElement(processedSelector);
+            // Get element location, scrolling it into view first so the
+            // mouse event lands inside the viewport
+            const elemResult = await this._findElement(processedSelector, { ensureInViewport: true });
 
             if (!elemResult) {
               // Try to find alternative selectors
@@ -2499,8 +2540,16 @@ class UnifiedBackend {
                   (() => {
                     const el = ${selectorExpr};
                     if (!el) return { error: 'Element not found' };
-                    el.scrollIntoView({ behavior: 'smooth', block: 'center' });
-                    return { success: true };
+                    // Instant, not smooth: smooth scrolling is animated, so
+                    // the command would return before the page has moved and
+                    // any coordinates measured afterwards would be stale
+                    el.scrollIntoView({ block: 'center', inline: 'center', behavior: 'instant' });
+                    const rect = el.getBoundingClientRect();
+                    return {
+                      success: true,
+                      scrollY: Math.round(window.scrollY),
+                      inViewport: rect.top >= 0 && rect.bottom <= window.innerHeight
+                    };
                   })()
                 `,
                 returnByValue: true
@@ -2511,7 +2560,11 @@ class UnifiedBackend {
               throw new Error(`${scrollResult.result.value.error}: ${action.selector}`);
             }
 
-            result = `Scrolled ${action.selector} into view`;
+            const scrollValue = scrollResult.result?.value || {};
+            result = `Scrolled ${action.selector} into view (scrollY: ${scrollValue.scrollY ?? 'unknown'})`;
+            if (scrollValue.inViewport === false) {
+              result += ' ⚠️ element still outside the viewport';
+            }
             break;
           }
 
@@ -2919,6 +2972,14 @@ class UnifiedBackend {
           (() => {
             const el = document.querySelector(${JSON.stringify(args.selector)});
             if (!el) return null;
+            // Scroll into view first: mouse events are dispatched in
+            // viewport space, so a below-the-fold element would otherwise
+            // be clicked at a point outside the window
+            const before = el.getBoundingClientRect();
+            if (before.top < 0 || before.bottom > window.innerHeight ||
+                before.left < 0 || before.right > window.innerWidth) {
+              el.scrollIntoView({ block: 'center', inline: 'center', behavior: 'instant' });
+            }
             const rect = el.getBoundingClientRect();
             return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
           })()
@@ -2964,6 +3025,147 @@ class UnifiedBackend {
     };
   }
 
+  /**
+   * Key event metadata for one typed character: the physical `code`, the
+   * virtual key code, and whether the character requires Shift. Editors
+   * that gate on keydown (canvas apps like Google Sheets) read these, so
+   * the mapping covers the full US-keyboard printable set. Characters
+   * outside it (accented letters, CJK, emoji) still carry `text`, which
+   * standard inputs use for insertion.
+   */
+  _keyEventParamsForChar(char) {
+    // US layout: unshifted char -> [code, shifted char]
+    const KEY_LAYOUT = {
+      '`': ['Backquote', '~'], '-': ['Minus', '_'], '=': ['Equal', '+'],
+      '[': ['BracketLeft', '{'], ']': ['BracketRight', '}'], '\\': ['Backslash', '|'],
+      ';': ['Semicolon', ':'], "'": ['Quote', '"'], ',': ['Comma', '<'],
+      '.': ['Period', '>'], '/': ['Slash', '?'], ' ': ['Space', ' ']
+    };
+    const DIGIT_SHIFTED = ')!@#$%^&*(';
+
+    let code = '';
+    let virtualKeyCode = 0;
+    let shift = false;
+
+    if (/[a-zA-Z]/.test(char)) {
+      const upper = char.toUpperCase();
+      code = `Key${upper}`;
+      virtualKeyCode = upper.charCodeAt(0);
+      shift = char !== char.toLowerCase();
+    } else if (/[0-9]/.test(char)) {
+      code = `Digit${char}`;
+      virtualKeyCode = char.charCodeAt(0);
+    } else if (DIGIT_SHIFTED.includes(char)) {
+      const digit = String(DIGIT_SHIFTED.indexOf(char));
+      code = `Digit${digit}`;
+      virtualKeyCode = digit.charCodeAt(0);
+      shift = true;
+    } else if (KEY_LAYOUT[char]) {
+      code = KEY_LAYOUT[char][0];
+      virtualKeyCode = char === ' ' ? 32 : char.charCodeAt(0);
+    } else {
+      const unshifted = Object.keys(KEY_LAYOUT).find(k => KEY_LAYOUT[k][1] === char);
+      if (unshifted) {
+        code = KEY_LAYOUT[unshifted][0];
+        virtualKeyCode = unshifted.charCodeAt(0);
+        shift = true;
+      }
+    }
+
+    return {
+      key: char,
+      code,
+      windowsVirtualKeyCode: virtualKeyCode,
+      nativeVirtualKeyCode: virtualKeyCode,
+      modifiers: shift ? 8 : 0, // CDP modifier bit 8 = Shift
+      text: char,
+      unmodifiedText: char
+    };
+  }
+
+  /**
+   * Key event metadata for a named key (Enter, Tab, arrows...). Single
+   * characters fall through to _keyEventParamsForChar so typing and
+   * press_key emit identical events for the same keystroke.
+   */
+  _keyEventParamsForKey(key) {
+    const NAMED_KEYS = {
+      Enter: 13, Escape: 27, Tab: 9, Backspace: 8, Delete: 46,
+      ArrowUp: 38, ArrowDown: 40, ArrowLeft: 37, ArrowRight: 39,
+      Space: 32, Home: 36, End: 35, PageUp: 33, PageDown: 34
+    };
+
+    if (key.length === 1) {
+      return this._keyEventParamsForChar(key);
+    }
+
+    const virtualKeyCode = NAMED_KEYS[key] || 0;
+    const text = key === 'Enter' ? '\r' : (key === 'Tab' ? '\t' : '');
+    return {
+      key,
+      code: key === 'Space' ? 'Space' : key,
+      windowsVirtualKeyCode: virtualKeyCode,
+      nativeVirtualKeyCode: virtualKeyCode,
+      modifiers: 0,
+      text,
+      unmodifiedText: text
+    };
+  }
+
+  /**
+   * Press one key as a keyDown/keyUp pair
+   */
+  async _pressKey(key) {
+    const params = this._keyEventParamsForKey(key);
+    for (const type of ['keyDown', 'keyUp']) {
+      await this._transport.sendCommand('forwardCDPCommand', {
+        method: 'Input.dispatchKeyEvent',
+        params: { type, ...params }
+      });
+    }
+  }
+
+  /**
+   * Type text as full keyDown/keyUp sequences. The keyDown carries the
+   * text (which performs the insertion — no separate 'char' event, that
+   * would double-insert in standard inputs), and canvas-based editors
+   * like Google Sheets require the full sequence with key codes to
+   * commit the input (issue #36).
+   *
+   * Newlines are the exception: they are sent as an inert 'char' event.
+   * A trusted Enter keyDown submits forms, so typing multi-line text
+   * would navigate away mid-string — callers wanting a real Enter use
+   * the press_key action explicitly.
+   */
+  async _typeText(text) {
+    for (const char of text) {
+      if (char === '\n' || char === '\r') {
+        await this._transport.sendCommand('forwardCDPCommand', {
+          method: 'Input.dispatchKeyEvent',
+          params: { type: 'char', text: '\n' }
+        });
+        continue;
+      }
+
+      const params = this._keyEventParamsForChar(char);
+      await this._transport.sendCommand('forwardCDPCommand', {
+        method: 'Input.dispatchKeyEvent',
+        params: { type: 'keyDown', ...params }
+      });
+      await this._transport.sendCommand('forwardCDPCommand', {
+        method: 'Input.dispatchKeyEvent',
+        params: {
+          type: 'keyUp',
+          key: params.key,
+          code: params.code,
+          windowsVirtualKeyCode: params.windowsVirtualKeyCode,
+          nativeVirtualKeyCode: params.nativeVirtualKeyCode,
+          modifiers: params.modifiers
+        }
+      });
+    }
+  }
+
   async _handleType(args) {
     // Focus element first
     await this._transport.sendCommand('forwardCDPCommand', {
@@ -2974,16 +3176,7 @@ class UnifiedBackend {
       }
     });
 
-    // Type each character
-    for (const char of args.text) {
-      await this._transport.sendCommand('forwardCDPCommand', {
-        method: 'Input.dispatchKeyEvent',
-        params: {
-          type: 'char',
-          text: char
-        }
-      });
-    }
+    await this._typeText(args.text);
 
     return {
       content: [{
@@ -2996,50 +3189,7 @@ class UnifiedBackend {
 
   async _handlePressKey(args) {
     const key = args.key;
-
-    // Map common keys to their key codes
-    const keyCodeMap = {
-      'Enter': 13,
-      'Escape': 27,
-      'Tab': 9,
-      'Backspace': 8,
-      'Delete': 46,
-      'ArrowUp': 38,
-      'ArrowDown': 40,
-      'ArrowLeft': 37,
-      'ArrowRight': 39,
-      'Space': 32
-    };
-
-    const code = keyCodeMap[key];
-    const text = key === 'Enter' ? '\r' : (key === 'Tab' ? '\t' : (key.length === 1 ? key : ''));
-
-    const baseParams = {
-      key: key,
-      code: key,
-      windowsVirtualKeyCode: code,
-      nativeVirtualKeyCode: code,
-      text: text,
-      unmodifiedText: text
-    };
-
-    // Send keyDown
-    await this._transport.sendCommand('forwardCDPCommand', {
-      method: 'Input.dispatchKeyEvent',
-      params: {
-        type: 'keyDown',
-        ...baseParams
-      }
-    });
-
-    // Send keyUp
-    await this._transport.sendCommand('forwardCDPCommand', {
-      method: 'Input.dispatchKeyEvent',
-      params: {
-        type: 'keyUp',
-        ...baseParams
-      }
-    });
+    await this._pressKey(key);
 
     return {
       content: [{
@@ -3059,6 +3209,14 @@ class UnifiedBackend {
           (() => {
             const el = document.querySelector(${JSON.stringify(args.selector)});
             if (!el) return null;
+            // Scroll into view first: mouse events are dispatched in
+            // viewport space, so a below-the-fold element would otherwise
+            // be clicked at a point outside the window
+            const before = el.getBoundingClientRect();
+            if (before.top < 0 || before.bottom > window.innerHeight ||
+                before.left < 0 || before.right > window.innerWidth) {
+              el.scrollIntoView({ block: 'center', inline: 'center', behavior: 'instant' });
+            }
             const rect = el.getBoundingClientRect();
             return { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
           })()
@@ -4897,22 +5055,26 @@ This request was captured by the browser extension's background tracker (webRequ
   async _handleListExtensions(options = {}) {
     const result = await this._transport.sendCommand('listExtensions', {});
 
+    // The extension returns only { extensions }; count is derived here so
+    // the header doesn't render "Total: undefined"
+    const extensions = result.extensions || [];
+
     if (options.rawResult) {
       return {
         success: true,
-        count: result.count || 0,
-        extensions: result.extensions || []
+        count: extensions.length,
+        extensions
       };
     }
 
-    const extList = (result.extensions || [])
+    const extList = extensions
       .map(ext => `- ${ext.name} (v${ext.version}) ${ext.enabled ? '[enabled]' : '[disabled]'}`)
       .join('\n');
 
     return {
       content: [{
         type: 'text',
-        text: `### Browser Extensions\n\nTotal: ${result.count}\n\n${extList}`
+        text: `### Browser Extensions\n\nTotal: ${extensions.length}\n\n${extList}`
       }],
       isError: false
     };


### PR DESCRIPTION
## Summary

Pre-release bundle for v1.9.22. Every fix here was verified against a real browser by running the procedures in `docs/testing/` — which is also how the three most serious bugs were found.

### Clicks and scrolling (the big one)
- **Clicks below the fold were silently doing nothing.** Mouse events are dispatched in viewport space, but element coordinates were measured without scrolling, so an element at page y=3673 in a 757px viewport was clicked at viewport y=3673 — outside the window. The event hit nothing while the tool reported `✓ Clicked`. Clicks and hovers now scroll the target into view and re-measure first.
- `scroll_into_view` used **smooth (animated)** scrolling and returned before the page moved, leaving any coordinates measured afterwards stale. It now scrolls instantly, reports the resulting scroll position, and warns if the element still can't be brought into view.
- This is what made the dialog tests unreachable; with the fix, alert/confirm/prompt all fire and are auto-handled correctly (including configured prompt text).

### Tabs
- **One canonical ordering** (`getOrderedTabs`) now serves list, attach, create and close. Previously attach/create used `tabs.query` while list/close used `windows.getAll` flattening, so an index from a listing could resolve to a different tab across windows.
- Tab indexes are validated as integers — a missing or fractional index gives a range error instead of an opaque TypeError.
- **`openTestPage` never attached to the page it opened**, so it reported "auto-attached" while every following command ran against the previous tab.
- `Target.attachToTarget`/`Target.createTarget` passed bare values to handlers expecting params objects (attach selected nothing; create always opened about:blank).

### Startup and connection
- Background init steps are individually guarded via a shared `safeInit` helper, with a prefixed fatal error if initialization fails, so one failing step can't stop the extension from connecting (issue #49). Chrome previously had no guards and no catch at all.
- The session timestamp is set when a session is genuinely established (socket accept in Free mode, successful auth in PRO) and rolled back when the server refuses the connection, so a rejection loop can't look like a healthy connection.

### Typing
- Typed characters carry correct key codes across the printable US keyboard including shifted characters, so keydown-gated editors (Google Sheets, issue #36) get usable events. Newline behaviour is unchanged and now documented in the tool schema.

Also: `browser_list_extensions` no longer renders "Total: undefined".

## Testing

- `server`: `npm test` — 76 passed
- `extensions/chrome`: `npm run build` — lint + build pass
- Firefox and shared modules syntax-checked (not covered by CI)
- **Manual suite:** ~60 of the 90 documented cases run live against Chrome — tab management across 4 windows, interactions, forms/lookup, content extraction, network (both capture paths, replay, filters, clear), console, verification, advanced tools (window/pdf/perf/styles/drag), dialogs, and a full disable→enable reconnect cycle. Not run: file upload (needs fixtures), the 12 navigation side-effects cases, and PRO/OAuth (file 10).

Closes the click/scroll issue tracked as mcp-cc68.