### PR TITLE
Fix publish workflow: npm version pin and extension cache path

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -26,7 +26,7 @@ jobs:
           cache-dependency-path: 'server/package-lock.json'
       # Ensure npm 11.5.1 or later is installed (for OIDC npm publishing)
       - name: Update npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@^11.5.1
 
       - name: Get current date
         id: date
@@ -69,7 +69,7 @@ jobs:
           cache-dependency-path: 'server/package-lock.json'
       # Ensure npm 11.5.1 or later is installed (for OIDC npm publishing)
       - name: Update npm
-        run: npm install -g npm@latest
+        run: npm install -g npm@^11.5.1
       - run: npm ci
       - run: npm run test
       - run: npm publish
@@ -85,6 +85,7 @@ jobs:
         with:
           node-version: 20
           cache: 'npm'
+          cache-dependency-path: 'extensions/chrome/package-lock.json'
       - name: Install extension dependencies
         working-directory: ./extensions/chrome
         run: npm ci


### PR DESCRIPTION
The v1.9.22 release exposed two pre-existing failures in `publish.yml` — the npm package was not published and both release jobs failed.

**1. `npm install -g npm@latest` is incompatible with the pinned Node version.**
`npm@latest` now resolves to npm 12, which requires Node `^22.22.2 || ^24.15.0 || >=26.0.0`, while the publish jobs pin `node-version: 20`:

```
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"10.8.2","node":"v20.20.2"}
```

Pinned to `npm@^11.5.1` instead, which still satisfies the minimum for OIDC trusted publishing and works on Node 20. This also explains why the nightly canary publishes have been failing.

**2. `package-release-extension` caches npm with no lock file to key on.**
The job sets `cache: 'npm'` without `cache-dependency-path`, and there is no lock file at the repository root, so `setup-node` failed before any build step:

```
Dependencies lock file is not found in /home/runner/work/blueprint-mcp/blueprint-mcp
```

Pointed it at `extensions/chrome/package-lock.json`, matching what the job actually installs.

Once merged, the v1.9.22 release publish can be re-run to push the package to npm.